### PR TITLE
feat: multi-target package to net8.0, net9.0, net10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/Equibles.ParadeDB.EntityFrameworkCore.Tests.csproj
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/Equibles.ParadeDB.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -11,9 +11,20 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Equibles.ParadeDB.EntityFrameworkCore/Equibles.ParadeDB.EntityFrameworkCore.csproj
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Equibles.ParadeDB.EntityFrameworkCore.csproj
@@ -1,14 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Description>EF Core integration for ParadeDB pg_search BM25 full-text search indexes on PostgreSQL. Provides a [Bm25Index] attribute, UseParadeDb() extension, and LINQ query methods for BM25 search, scoring, and snippets.</Description>
         <PackageId>Equibles.ParadeDB.EntityFrameworkCore</PackageId>
         <!-- PgUnknownBinaryExpression is an Npgsql internal API used by all PostgreSQL EF Core extensions (pgvector, etc.) for custom operators -->
         <NoWarn>EF1001</NoWarn>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModifiedQueryExpression.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModifiedQueryExpression.cs
@@ -35,8 +35,10 @@ public sealed class ParadeDbModifiedQueryExpression : SqlExpression {
         && InnerExpression.Equals(other.InnerExpression)
         && ModifierSuffix == other.ModifierSuffix;
 
+#if NET9_0_OR_GREATER
     public override Expression Quote() =>
         throw new NotSupportedException("ParadeDB expressions do not support precompiled queries.");
+#endif
 
     public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), InnerExpression, ModifierSuffix);
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbNamedArgFunctionExpression.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbNamedArgFunctionExpression.cs
@@ -80,8 +80,10 @@ public sealed class ParadeDbNamedArgFunctionExpression : SqlExpression {
         return true;
     }
 
+#if NET9_0_OR_GREATER
     public override Expression Quote() =>
         throw new NotSupportedException("ParadeDB expressions do not support precompiled queries.");
+#endif
 
     public override int GetHashCode() {
         var hash = new HashCode();

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbParameterBasedSqlProcessor.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbParameterBasedSqlProcessor.cs
@@ -6,6 +6,38 @@ namespace Equibles.ParadeDB.EntityFrameworkCore;
 
 public class ParadeDbParameterBasedSqlProcessor : NpgsqlParameterBasedSqlProcessor {
     private readonly RelationalParameterBasedSqlProcessorDependencies _dependencies;
+
+#if NET8_0
+    private readonly bool _useRelationalNulls;
+
+    public ParadeDbParameterBasedSqlProcessor(RelationalParameterBasedSqlProcessorDependencies dependencies,
+        bool useRelationalNulls)
+        : base(dependencies, useRelationalNulls) {
+        _dependencies = dependencies;
+        _useRelationalNulls = useRelationalNulls;
+    }
+
+    protected override Expression ProcessSqlNullability(Expression selectExpression,
+        IReadOnlyDictionary<string, object> parametersValues, out bool canCache) {
+        return new ParadeDbSqlNullabilityProcessor(_dependencies, _useRelationalNulls)
+            .Process(selectExpression, parametersValues, out canCache);
+    }
+#elif NET9_0
+    private readonly RelationalParameterBasedSqlProcessorParameters _parameters;
+
+    public ParadeDbParameterBasedSqlProcessor(RelationalParameterBasedSqlProcessorDependencies dependencies,
+        RelationalParameterBasedSqlProcessorParameters parameters)
+        : base(dependencies, parameters) {
+        _dependencies = dependencies;
+        _parameters = parameters;
+    }
+
+    protected override Expression ProcessSqlNullability(Expression selectExpression,
+        IReadOnlyDictionary<string, object> parametersValues, out bool canCache) {
+        return new ParadeDbSqlNullabilityProcessor(_dependencies, _parameters)
+            .Process(selectExpression, parametersValues, out canCache);
+    }
+#else
     private readonly RelationalParameterBasedSqlProcessorParameters _parameters;
 
     public ParadeDbParameterBasedSqlProcessor(RelationalParameterBasedSqlProcessorDependencies dependencies,
@@ -19,4 +51,5 @@ public class ParadeDbParameterBasedSqlProcessor : NpgsqlParameterBasedSqlProcess
         return new ParadeDbSqlNullabilityProcessor(_dependencies, _parameters)
             .Process(expression, parametersDecorator);
     }
+#endif
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbParameterBasedSqlProcessorFactory.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbParameterBasedSqlProcessorFactory.cs
@@ -11,6 +11,11 @@ public class ParadeDbParameterBasedSqlProcessorFactory : NpgsqlParameterBasedSql
         _dependencies = dependencies;
     }
 
+#if NET8_0
+    public override RelationalParameterBasedSqlProcessor Create(bool useRelationalNulls)
+        => new ParadeDbParameterBasedSqlProcessor(_dependencies, useRelationalNulls);
+#else
     public override RelationalParameterBasedSqlProcessor Create(RelationalParameterBasedSqlProcessorParameters parameters)
         => new ParadeDbParameterBasedSqlProcessor(_dependencies, parameters);
+#endif
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbSqlNullabilityProcessor.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbSqlNullabilityProcessor.cs
@@ -5,10 +5,17 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
 namespace Equibles.ParadeDB.EntityFrameworkCore;
 
 public class ParadeDbSqlNullabilityProcessor : NpgsqlSqlNullabilityProcessor {
+#if NET8_0
+    public ParadeDbSqlNullabilityProcessor(RelationalParameterBasedSqlProcessorDependencies dependencies,
+        bool useRelationalNulls)
+        : base(dependencies, useRelationalNulls) {
+    }
+#else
     public ParadeDbSqlNullabilityProcessor(RelationalParameterBasedSqlProcessorDependencies dependencies,
         RelationalParameterBasedSqlProcessorParameters parameters)
         : base(dependencies, parameters) {
     }
+#endif
 
     protected override SqlExpression VisitCustomSqlExpression(SqlExpression sqlExpression,
         bool allowOptimizedExpansion, out bool nullable) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a `[Bm25Index]` attribute for automatic index creation via migrations, 
 
 - PostgreSQL with the [pg_search](https://docs.paradedb.com/search/quickstart) extension installed
 - [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL) provider
-- .NET 10+
+- .NET 8, 9, or 10
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Adds support for EF Core 8 and 9 alongside the existing EF Core 10 target, with TFM-conditional `Npgsql.EntityFrameworkCore.PostgreSQL` references (8.0.11 / 9.0.4 / 10.0.1).
- Multi-targets the test project to the same three TFMs; all 65 translation tests pass on each runtime, exercising the conditional code paths end-to-end.
- Bumps package version `0.1.0` -> `0.1.1`.

## Code changes

- `Directory.Build.props` — removes hardcoded `<TargetFramework>` (now set per-project) and bumps `<Version>` to `0.1.1`.
- `Equibles.ParadeDB.EntityFrameworkCore.csproj` — `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>` plus version-conditioned Npgsql package references per TFM.
- `Equibles.ParadeDB.EntityFrameworkCore.Tests.csproj` — same multi-targeting and conditional package references so tests run on all three runtimes.
- `ParadeDbModifiedQueryExpression.cs`, `ParadeDbNamedArgFunctionExpression.cs` — wraps the `Quote()` override in `#if NET9_0_OR_GREATER` (the virtual was added in EF Core 9).
- `ParadeDbParameterBasedSqlProcessor.cs` — three `#if` branches: EF 8 ctor takes `(deps, bool useRelationalNulls)`; EF 9 ctor takes `(deps, RelationalParameterBasedSqlProcessorParameters)`; EF 10 changes `ProcessSqlNullability` to `(Expression, ParametersCacheDecorator)`.
- `ParadeDbParameterBasedSqlProcessorFactory.cs` — `#if NET8_0` for the older `Create(bool)` factory signature.
- `ParadeDbSqlNullabilityProcessor.cs` — `#if NET8_0` for the older `(deps, bool)` base constructor.
- `README.md` — requirements updated from ".NET 10+" to ".NET 8, 9, or 10".