### PR TITLE
feat: add per-column BM25 index config via attribute set

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
@@ -1,0 +1,307 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.Tests;
+
+public class Bm25IndexConfigurationTests {
+    private static string GetCreateScript<TEntity>() where TEntity : class {
+        using var ctx = new ConfigTestContext<TEntity>();
+        return ctx.Database.GenerateCreateScript();
+    }
+
+    [Fact]
+    public void EntityWithoutPerColumnAttributes_EmitsOnlyKeyField() {
+        var sql = GetCreateScript<PlainEntity>();
+        Assert.Contains("key_field='Id'", sql);
+        Assert.DoesNotContain("text_fields=", sql);
+        Assert.DoesNotContain("numeric_fields=", sql);
+        Assert.DoesNotContain("boolean_fields=", sql);
+        Assert.DoesNotContain("datetime_fields=", sql);
+        Assert.DoesNotContain("json_fields=", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithEnglishStemmer_EmitsStemmerInTokenizer() {
+        var sql = GetCreateScript<EnglishStemmerEntity>();
+        Assert.Contains("""text_fields='{"Content":{"tokenizer":{"type":"default","stemmer":"English"}}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithRawTokenizer_EmitsRawType() {
+        var sql = GetCreateScript<RawTokenizerEntity>();
+        Assert.Contains("""text_fields='{"Slug":{"tokenizer":{"type":"raw"}}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithStopwordsLanguage_EmitsStopwordsKey() {
+        var sql = GetCreateScript<StopwordsEntity>();
+        Assert.Contains("\"stopwords_language\":\"French\"", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithNgramTokenizer_EmitsMinMaxGram() {
+        var sql = GetCreateScript<NgramEntity>();
+        Assert.Contains("""text_fields='{"Content":{"tokenizer":{"type":"ngram","min_gram":2,"max_gram":4}}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithNgramAndPrefixOnly_EmitsPrefixOnly() {
+        var sql = GetCreateScript<NgramPrefixEntity>();
+        Assert.Contains("\"prefix_only\":true", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithRegexTokenizer_EmitsPattern() {
+        var sql = GetCreateScript<RegexEntity>();
+        Assert.Contains("\"type\":\"regex\"", sql);
+        Assert.Contains("\"pattern\":", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithFastTrue_EmitsFastKey() {
+        var sql = GetCreateScript<FastTextEntity>();
+        Assert.Contains("\"fast\":true", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithRecordPosition_EmitsRecordKey() {
+        var sql = GetCreateScript<RecordPositionEntity>();
+        Assert.Contains("\"record\":\"position\"", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithIndexedFalse_EmitsIndexedFalse() {
+        var sql = GetCreateScript<NotIndexedTextEntity>();
+        Assert.Contains("\"indexed\":false", sql);
+    }
+
+    [Fact]
+    public void Bm25Text_WithFieldnormsFalse_EmitsFieldnormsFalse() {
+        var sql = GetCreateScript<NoFieldnormsEntity>();
+        Assert.Contains("\"fieldnorms\":false", sql);
+    }
+
+    [Fact]
+    public void Bm25Numeric_WithFastTrue_EmitsNumericFields() {
+        var sql = GetCreateScript<NumericEntity>();
+        Assert.Contains("""numeric_fields='{"Rating":{"fast":true}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25Boolean_WithFastTrue_EmitsBooleanFields() {
+        var sql = GetCreateScript<BooleanEntity>();
+        Assert.Contains("""boolean_fields='{"InStock":{"fast":true}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25DateTime_WithFastTrue_EmitsDatetimeFields() {
+        var sql = GetCreateScript<DateTimeEntity>();
+        Assert.Contains("""datetime_fields='{"PublishedAt":{"fast":true}}'""", sql);
+    }
+
+    [Fact]
+    public void Bm25Json_WithExpandDots_EmitsExpandDots() {
+        var sql = GetCreateScript<JsonEntity>();
+        Assert.Contains("json_fields=", sql);
+        Assert.Contains("\"expand_dots\":true", sql);
+    }
+
+    [Fact]
+    public void MixedFieldTypes_EmitSeparateStorageParameters() {
+        var sql = GetCreateScript<MixedEntity>();
+        Assert.Contains("text_fields=", sql);
+        Assert.Contains("numeric_fields=", sql);
+        Assert.Contains("boolean_fields=", sql);
+    }
+
+    [Fact]
+    public void NgramParamWithoutNgramTokenizer_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<InvalidNgramParamEntity>());
+        Assert.Contains("MinGram/MaxGram/PrefixOnly require Tokenizer = Bm25Tokenizer.Ngram", ex.Message);
+    }
+
+    [Fact]
+    public void NgramTokenizerWithoutMinMax_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<NgramMissingMinMaxEntity>());
+        Assert.Contains("Bm25Tokenizer.Ngram requires both MinGram and MaxGram", ex.Message);
+    }
+
+    [Fact]
+    public void RegexTokenizerWithoutPattern_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<RegexMissingPatternEntity>());
+        Assert.Contains("Bm25Tokenizer.Regex requires a RegexPattern", ex.Message);
+    }
+
+    [Fact]
+    public void OrphanFieldAttributeWithoutBm25Index_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<OrphanNoIndexEntity>());
+        Assert.Contains("OrphanText", ex.Message);
+        Assert.Contains("no [Bm25Index]", ex.Message);
+    }
+
+    [Fact]
+    public void FieldAttributeOnPropertyNotInIndexColumns_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<FieldAttrNotInIndexEntity>());
+        Assert.Contains("Untracked", ex.Message);
+        Assert.Contains("not listed in the [Bm25Index] columns", ex.Message);
+    }
+}
+
+internal sealed class ConfigTestContext<TEntity> : DbContext where TEntity : class {
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+        optionsBuilder.UseNpgsql("Host=localhost;Database=test", npgsql => npgsql.UseParadeDb());
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) {
+        modelBuilder.Entity<TEntity>();
+    }
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class PlainEntity {
+    public int Id { get; set; }
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class EnglishStemmerEntity {
+    public int Id { get; set; }
+    [Bm25Text(Stemmer = Bm25Language.English)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Slug))]
+internal class RawTokenizerEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Raw)]
+    public string Slug { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class StopwordsEntity {
+    public int Id { get; set; }
+    [Bm25Text(StopwordsLanguage = Bm25Language.French)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class NgramEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Ngram, MinGram = 2, MaxGram = 4)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class NgramPrefixEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Ngram, MinGram = 2, MaxGram = 4, PrefixOnly = true)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class RegexEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Regex, RegexPattern = "neuro.*")]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Title))]
+internal class FastTextEntity {
+    public int Id { get; set; }
+    [Bm25Text(Fast = true)]
+    public string Title { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class RecordPositionEntity {
+    public int Id { get; set; }
+    [Bm25Text(Record = Bm25Record.Position)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class NotIndexedTextEntity {
+    public int Id { get; set; }
+    [Bm25Text(Indexed = false)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class NoFieldnormsEntity {
+    public int Id { get; set; }
+    [Bm25Text(Fieldnorms = false)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Rating))]
+internal class NumericEntity {
+    public int Id { get; set; }
+    [Bm25Numeric(Fast = true)]
+    public int Rating { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(InStock))]
+internal class BooleanEntity {
+    public int Id { get; set; }
+    [Bm25Boolean(Fast = true)]
+    public bool InStock { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(PublishedAt))]
+internal class DateTimeEntity {
+    public int Id { get; set; }
+    [Bm25DateTime(Fast = true)]
+    public DateTime PublishedAt { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(Metadata))]
+internal class JsonEntity {
+    public int Id { get; set; }
+    [Bm25Json(ExpandDots = true)]
+    public string Metadata { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Title), nameof(Rating), nameof(InStock))]
+internal class MixedEntity {
+    public int Id { get; set; }
+    [Bm25Text(Fast = true)]
+    public string Title { get; set; } = null!;
+    [Bm25Numeric(Fast = true)]
+    public int Rating { get; set; }
+    [Bm25Boolean(Fast = true)]
+    public bool InStock { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class InvalidNgramParamEntity {
+    public int Id { get; set; }
+    [Bm25Text(MinGram = 2)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class NgramMissingMinMaxEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Ngram)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class RegexMissingPatternEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Regex)]
+    public string Content { get; set; } = null!;
+}
+
+internal class OrphanNoIndexEntity {
+    public int Id { get; set; }
+    [Bm25Text]
+    public string OrphanText { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Indexed))]
+internal class FieldAttrNotInIndexEntity {
+    public int Id { get; set; }
+    public string Indexed { get; set; } = null!;
+    [Bm25Text]
+    public string Untracked { get; set; } = null!;
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25BooleanAttribute.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25BooleanAttribute.cs
@@ -1,0 +1,10 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Configures a boolean column inside a BM25 index.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class Bm25BooleanAttribute : Attribute {
+    public bool Fast { get; set; }
+    public bool Indexed { get; set; } = true;
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25DateTimeAttribute.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25DateTimeAttribute.cs
@@ -1,0 +1,10 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Configures a datetime column inside a BM25 index.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class Bm25DateTimeAttribute : Attribute {
+    public bool Fast { get; set; }
+    public bool Indexed { get; set; } = true;
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25JsonAttribute.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25JsonAttribute.cs
@@ -1,0 +1,36 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Configures a json/jsonb column inside a BM25 index. Accepts the same text-field
+/// settings as <see cref="Bm25TextAttribute"/> plus <see cref="ExpandDots"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class Bm25JsonAttribute : Attribute {
+    public Bm25Tokenizer Tokenizer { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public int MinGram { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public int MaxGram { get; set; }
+
+    /// <summary>Optional. Only valid when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public bool PrefixOnly { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Regex"/>.</summary>
+    public string RegexPattern { get; set; }
+
+    public Bm25Language Stemmer { get; set; }
+    public Bm25Language StopwordsLanguage { get; set; }
+
+    public bool Fast { get; set; }
+    public Bm25Record Record { get; set; }
+    public bool Indexed { get; set; } = true;
+    public bool Fieldnorms { get; set; } = true;
+
+    /// <summary>
+    /// When true, dotted JSON keys such as "metadata.color" are expanded into nested objects
+    /// for indexing. Defaults to pg_search's own default (false) when not set.
+    /// </summary>
+    public bool ExpandDots { get; set; }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25Language.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25Language.cs
@@ -1,0 +1,29 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Languages supported by pg_search's stemmer and stopwords token filters.
+/// <see cref="Unspecified"/> means the property carries no language setting; the filter is not applied.
+/// </summary>
+public enum Bm25Language {
+    Unspecified = 0,
+    Arabic,
+    Czech,
+    Danish,
+    Dutch,
+    English,
+    Finnish,
+    French,
+    German,
+    Greek,
+    Hungarian,
+    Italian,
+    Norwegian,
+    Polish,
+    Portuguese,
+    Romanian,
+    Russian,
+    Spanish,
+    Swedish,
+    Tamil,
+    Turkish,
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25NumericAttribute.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25NumericAttribute.cs
@@ -1,0 +1,10 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Configures a numeric column inside a BM25 index.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class Bm25NumericAttribute : Attribute {
+    public bool Fast { get; set; }
+    public bool Indexed { get; set; } = true;
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25Record.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25Record.cs
@@ -1,0 +1,13 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// What term metadata pg_search stores in the index.
+/// Position is required for phrase queries; Basic and Freq use less disk.
+/// <see cref="Unspecified"/> means the property carries no record setting; pg_search uses its default.
+/// </summary>
+public enum Bm25Record {
+    Unspecified = 0,
+    Basic,
+    Freq,
+    Position,
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25TextAttribute.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25TextAttribute.cs
@@ -1,0 +1,30 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Configures a text column inside a BM25 index. The property must also be listed
+/// in the entity's <see cref="Bm25IndexAttribute"/> column set.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class Bm25TextAttribute : Attribute {
+    public Bm25Tokenizer Tokenizer { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public int MinGram { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public int MaxGram { get; set; }
+
+    /// <summary>Optional. Only valid when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Ngram"/>.</summary>
+    public bool PrefixOnly { get; set; }
+
+    /// <summary>Required when <see cref="Tokenizer"/> is <see cref="Bm25Tokenizer.Regex"/>.</summary>
+    public string RegexPattern { get; set; }
+
+    public Bm25Language Stemmer { get; set; }
+    public Bm25Language StopwordsLanguage { get; set; }
+
+    public bool Fast { get; set; }
+    public Bm25Record Record { get; set; }
+    public bool Indexed { get; set; } = true;
+    public bool Fieldnorms { get; set; } = true;
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Bm25Tokenizer.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Bm25Tokenizer.cs
@@ -1,0 +1,23 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore;
+
+/// <summary>
+/// Tokenization strategy for a text or json column in a BM25 index.
+/// Names map to pg_search tokenizer type strings.
+/// <see cref="Unspecified"/> means the property carries no tokenizer setting; pg_search uses its default.
+/// </summary>
+public enum Bm25Tokenizer {
+    Unspecified = 0,
+    Default,
+    Whitespace,
+    Raw,
+    Keyword,
+    SourceCode,
+    Icu,
+    Ngram,
+    Regex,
+    ChineseCompatible,
+    ChineseLindera,
+    JapaneseLindera,
+    KoreanLindera,
+    Jieba,
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25EnumExtensions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25EnumExtensions.cs
@@ -1,0 +1,54 @@
+namespace Equibles.ParadeDB.EntityFrameworkCore.Internal;
+
+internal static class Bm25EnumExtensions {
+    public static string ToParadeDbString(this Bm25Tokenizer tokenizer) => tokenizer switch {
+        Bm25Tokenizer.Unspecified => throw new ArgumentException("Bm25Tokenizer.Unspecified has no pg_search representation.", nameof(tokenizer)),
+        Bm25Tokenizer.Default => "default",
+        Bm25Tokenizer.Whitespace => "whitespace",
+        Bm25Tokenizer.Raw => "raw",
+        Bm25Tokenizer.Keyword => "keyword",
+        Bm25Tokenizer.SourceCode => "source_code",
+        Bm25Tokenizer.Icu => "icu",
+        Bm25Tokenizer.Ngram => "ngram",
+        Bm25Tokenizer.Regex => "regex",
+        Bm25Tokenizer.ChineseCompatible => "chinese_compatible",
+        Bm25Tokenizer.ChineseLindera => "chinese_lindera",
+        Bm25Tokenizer.JapaneseLindera => "japanese_lindera",
+        Bm25Tokenizer.KoreanLindera => "korean_lindera",
+        Bm25Tokenizer.Jieba => "jieba",
+        _ => throw new ArgumentOutOfRangeException(nameof(tokenizer), tokenizer, null),
+    };
+
+    public static string ToParadeDbString(this Bm25Language language) => language switch {
+        Bm25Language.Unspecified => throw new ArgumentException("Bm25Language.Unspecified has no pg_search representation.", nameof(language)),
+        Bm25Language.Arabic => "Arabic",
+        Bm25Language.Czech => "Czech",
+        Bm25Language.Danish => "Danish",
+        Bm25Language.Dutch => "Dutch",
+        Bm25Language.English => "English",
+        Bm25Language.Finnish => "Finnish",
+        Bm25Language.French => "French",
+        Bm25Language.German => "German",
+        Bm25Language.Greek => "Greek",
+        Bm25Language.Hungarian => "Hungarian",
+        Bm25Language.Italian => "Italian",
+        Bm25Language.Norwegian => "Norwegian",
+        Bm25Language.Polish => "Polish",
+        Bm25Language.Portuguese => "Portuguese",
+        Bm25Language.Romanian => "Romanian",
+        Bm25Language.Russian => "Russian",
+        Bm25Language.Spanish => "Spanish",
+        Bm25Language.Swedish => "Swedish",
+        Bm25Language.Tamil => "Tamil",
+        Bm25Language.Turkish => "Turkish",
+        _ => throw new ArgumentOutOfRangeException(nameof(language), language, null),
+    };
+
+    public static string ToParadeDbString(this Bm25Record record) => record switch {
+        Bm25Record.Unspecified => throw new ArgumentException("Bm25Record.Unspecified has no pg_search representation.", nameof(record)),
+        Bm25Record.Basic => "basic",
+        Bm25Record.Freq => "freq",
+        Bm25Record.Position => "position",
+        _ => throw new ArgumentOutOfRangeException(nameof(record), record, null),
+    };
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25StorageParameterBuilder.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25StorageParameterBuilder.cs
@@ -1,0 +1,118 @@
+using System.Text.Json.Nodes;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.Internal;
+
+internal static class Bm25StorageParameterBuilder {
+    public static string Serialize(JsonObject root) =>
+        root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = false });
+
+    public static JsonObject BuildTextField(Bm25TextAttribute attr, string propertyName) {
+        ValidateTokenizerParameters(
+            propertyName,
+            attr.Tokenizer,
+            attr.MinGram, attr.MaxGram, attr.PrefixOnly,
+            attr.RegexPattern);
+
+        var node = new JsonObject();
+        AddTokenizerKey(node, attr.Tokenizer, attr.MinGram, attr.MaxGram, attr.PrefixOnly, attr.RegexPattern,
+            attr.Stemmer, attr.StopwordsLanguage);
+        AddSharedKeys(node, attr.Fast, attr.Record, attr.Indexed, attr.Fieldnorms);
+        return node;
+    }
+
+    public static JsonObject BuildNumericField(Bm25NumericAttribute attr) {
+        var node = new JsonObject();
+        if (attr.Fast) node["fast"] = true;
+        if (!attr.Indexed) node["indexed"] = false;
+        return node;
+    }
+
+    public static JsonObject BuildBooleanField(Bm25BooleanAttribute attr) {
+        var node = new JsonObject();
+        if (attr.Fast) node["fast"] = true;
+        if (!attr.Indexed) node["indexed"] = false;
+        return node;
+    }
+
+    public static JsonObject BuildDateTimeField(Bm25DateTimeAttribute attr) {
+        var node = new JsonObject();
+        if (attr.Fast) node["fast"] = true;
+        if (!attr.Indexed) node["indexed"] = false;
+        return node;
+    }
+
+    public static JsonObject BuildJsonField(Bm25JsonAttribute attr, string propertyName) {
+        ValidateTokenizerParameters(
+            propertyName,
+            attr.Tokenizer,
+            attr.MinGram, attr.MaxGram, attr.PrefixOnly,
+            attr.RegexPattern);
+
+        var node = new JsonObject();
+        AddTokenizerKey(node, attr.Tokenizer, attr.MinGram, attr.MaxGram, attr.PrefixOnly, attr.RegexPattern,
+            attr.Stemmer, attr.StopwordsLanguage);
+        AddSharedKeys(node, attr.Fast, attr.Record, attr.Indexed, attr.Fieldnorms);
+        if (attr.ExpandDots) node["expand_dots"] = true;
+        return node;
+    }
+
+    private static void AddTokenizerKey(JsonObject node, Bm25Tokenizer tokenizer,
+        int minGram, int maxGram, bool prefixOnly, string regexPattern,
+        Bm25Language stemmer, Bm25Language stopwordsLanguage) {
+        var hasAnySetting = tokenizer != Bm25Tokenizer.Unspecified
+            || stemmer != Bm25Language.Unspecified
+            || stopwordsLanguage != Bm25Language.Unspecified;
+        if (!hasAnySetting) return;
+
+        var effectiveTokenizer = tokenizer == Bm25Tokenizer.Unspecified
+            ? Bm25Tokenizer.Default
+            : tokenizer;
+
+        var tok = new JsonObject {
+            ["type"] = effectiveTokenizer.ToParadeDbString(),
+        };
+
+        if (effectiveTokenizer == Bm25Tokenizer.Ngram) {
+            tok["min_gram"] = minGram;
+            tok["max_gram"] = maxGram;
+            if (prefixOnly) tok["prefix_only"] = true;
+        }
+        if (effectiveTokenizer == Bm25Tokenizer.Regex) {
+            tok["pattern"] = regexPattern;
+        }
+        if (stemmer != Bm25Language.Unspecified) tok["stemmer"] = stemmer.ToParadeDbString();
+        if (stopwordsLanguage != Bm25Language.Unspecified) tok["stopwords_language"] = stopwordsLanguage.ToParadeDbString();
+
+        node["tokenizer"] = tok;
+    }
+
+    private static void AddSharedKeys(JsonObject node, bool fast, Bm25Record record, bool indexed, bool fieldnorms) {
+        if (fast) node["fast"] = true;
+        if (record != Bm25Record.Unspecified) node["record"] = record.ToParadeDbString();
+        if (!indexed) node["indexed"] = false;
+        if (!fieldnorms) node["fieldnorms"] = false;
+    }
+
+    private static void ValidateTokenizerParameters(string propertyName, Bm25Tokenizer tokenizer,
+        int minGram, int maxGram, bool prefixOnly, string regexPattern) {
+        var hasNgramParam = minGram != 0 || maxGram != 0 || prefixOnly;
+        var hasRegexParam = regexPattern is not null;
+
+        if (hasNgramParam && tokenizer != Bm25Tokenizer.Ngram) {
+            throw new InvalidOperationException(
+                $"Property '{propertyName}': MinGram/MaxGram/PrefixOnly require Tokenizer = Bm25Tokenizer.Ngram.");
+        }
+        if (tokenizer == Bm25Tokenizer.Ngram && (minGram == 0 || maxGram == 0)) {
+            throw new InvalidOperationException(
+                $"Property '{propertyName}': Tokenizer = Bm25Tokenizer.Ngram requires both MinGram and MaxGram (> 0).");
+        }
+        if (hasRegexParam && tokenizer != Bm25Tokenizer.Regex) {
+            throw new InvalidOperationException(
+                $"Property '{propertyName}': RegexPattern requires Tokenizer = Bm25Tokenizer.Regex.");
+        }
+        if (tokenizer == Bm25Tokenizer.Regex && !hasRegexParam) {
+            throw new InvalidOperationException(
+                $"Property '{propertyName}': Tokenizer = Bm25Tokenizer.Regex requires a RegexPattern.");
+        }
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModelFinalizingConvention.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModelFinalizingConvention.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
+using System.Text.Json.Nodes;
+using Equibles.ParadeDB.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
@@ -11,6 +14,9 @@ public sealed class ParadeDbModelFinalizingConvention : IModelFinalizingConventi
 
         foreach (var entityType in modelBuilder.Metadata.GetEntityTypes()) {
             var attribute = entityType.ClrType.GetCustomAttribute<Bm25IndexAttribute>();
+
+            ValidateNoOrphanFieldAttributes(entityType, attribute);
+
             if (attribute == null) continue;
 
             var indexBuilder = entityType.Builder.HasIndex(attribute.Columns, fromDataAnnotation: true);
@@ -18,10 +24,11 @@ public sealed class ParadeDbModelFinalizingConvention : IModelFinalizingConventi
 
             indexBuilder.HasAnnotation("Npgsql:IndexMethod", "bm25", fromDataAnnotation: true);
 
-            // Resolve the key field to the actual column name
             var keyProperty = entityType.FindProperty(attribute.KeyField);
             var keyColumnName = keyProperty?.GetColumnName() ?? attribute.KeyField;
             indexBuilder.HasAnnotation("Npgsql:StorageParameter:key_field", keyColumnName, fromDataAnnotation: true);
+
+            BuildFieldTypeAnnotations(entityType, attribute, indexBuilder);
 
             hasBm25Index = true;
         }
@@ -29,5 +36,91 @@ public sealed class ParadeDbModelFinalizingConvention : IModelFinalizingConventi
         if (hasBm25Index) {
             modelBuilder.HasAnnotation("Npgsql:PostgresExtension:pg_search", ",,", fromDataAnnotation: true);
         }
+    }
+
+    private static void ValidateNoOrphanFieldAttributes(IConventionEntityType entityType, Bm25IndexAttribute attribute) {
+        foreach (var property in entityType.GetProperties()) {
+            var propertyInfo = property.PropertyInfo;
+            if (propertyInfo == null) continue;
+
+            var hasFieldAttr =
+                propertyInfo.GetCustomAttribute<Bm25TextAttribute>() != null
+                || propertyInfo.GetCustomAttribute<Bm25NumericAttribute>() != null
+                || propertyInfo.GetCustomAttribute<Bm25BooleanAttribute>() != null
+                || propertyInfo.GetCustomAttribute<Bm25DateTimeAttribute>() != null
+                || propertyInfo.GetCustomAttribute<Bm25JsonAttribute>() != null;
+
+            if (!hasFieldAttr) continue;
+
+            if (attribute == null) {
+                throw new InvalidOperationException(
+                    $"Property '{entityType.ClrType.Name}.{property.Name}' has a BM25 field attribute, " +
+                    "but the entity has no [Bm25Index] attribute.");
+            }
+
+            if (Array.IndexOf(attribute.Columns, property.Name) < 0) {
+                throw new InvalidOperationException(
+                    $"Property '{entityType.ClrType.Name}.{property.Name}' has a BM25 field attribute, " +
+                    "but it is not listed in the [Bm25Index] columns.");
+            }
+        }
+    }
+
+    private static void BuildFieldTypeAnnotations(IConventionEntityType entityType, Bm25IndexAttribute attribute,
+        IConventionIndexBuilder indexBuilder) {
+        var textFields = new JsonObject();
+        var numericFields = new JsonObject();
+        var booleanFields = new JsonObject();
+        var datetimeFields = new JsonObject();
+        var jsonFields = new JsonObject();
+
+        foreach (var propertyName in attribute.Columns) {
+            if (propertyName == attribute.KeyField) continue;
+
+            var property = entityType.FindProperty(propertyName);
+            var propertyInfo = property?.PropertyInfo;
+            if (propertyInfo == null) continue;
+
+            var columnName = property.GetColumnName() ?? propertyName;
+
+            var textAttr = propertyInfo.GetCustomAttribute<Bm25TextAttribute>();
+            if (textAttr != null) {
+                textFields[columnName] = Bm25StorageParameterBuilder.BuildTextField(textAttr, propertyName);
+                continue;
+            }
+            var numAttr = propertyInfo.GetCustomAttribute<Bm25NumericAttribute>();
+            if (numAttr != null) {
+                numericFields[columnName] = Bm25StorageParameterBuilder.BuildNumericField(numAttr);
+                continue;
+            }
+            var boolAttr = propertyInfo.GetCustomAttribute<Bm25BooleanAttribute>();
+            if (boolAttr != null) {
+                booleanFields[columnName] = Bm25StorageParameterBuilder.BuildBooleanField(boolAttr);
+                continue;
+            }
+            var dtAttr = propertyInfo.GetCustomAttribute<Bm25DateTimeAttribute>();
+            if (dtAttr != null) {
+                datetimeFields[columnName] = Bm25StorageParameterBuilder.BuildDateTimeField(dtAttr);
+                continue;
+            }
+            var jsonAttr = propertyInfo.GetCustomAttribute<Bm25JsonAttribute>();
+            if (jsonAttr != null) {
+                jsonFields[columnName] = Bm25StorageParameterBuilder.BuildJsonField(jsonAttr, propertyName);
+            }
+        }
+
+        AddFieldGroupParameter(indexBuilder, "text_fields", textFields);
+        AddFieldGroupParameter(indexBuilder, "numeric_fields", numericFields);
+        AddFieldGroupParameter(indexBuilder, "boolean_fields", booleanFields);
+        AddFieldGroupParameter(indexBuilder, "datetime_fields", datetimeFields);
+        AddFieldGroupParameter(indexBuilder, "json_fields", jsonFields);
+    }
+
+    private static void AddFieldGroupParameter(IConventionIndexBuilder indexBuilder, string name, JsonObject group) {
+        if (group.Count == 0) return;
+        indexBuilder.HasAnnotation(
+            $"Npgsql:StorageParameter:{name}",
+            Bm25StorageParameterBuilder.Serialize(group),
+            fromDataAnnotation: true);
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,54 @@ public class Article
 
 The first parameter is the **key field** (required by pg_search to identify rows for scoring via `pdb.score()`), followed by the columns to index for full-text search. The key field is not searchable — it's only used internally by ParadeDB.
 
-### 3. Create a migration
+### 3. (Optional) Configure per-column index settings
+
+Drop column-level attributes on the indexed properties to tune tokenization, stemming, stopwords, fast-storage, and field-specific options. Anything you don't set keeps pg_search's defaults.
+
+```csharp
+using Equibles.ParadeDB.EntityFrameworkCore;
+
+[Bm25Index(nameof(Id), nameof(Title), nameof(Content), nameof(Category), nameof(Rating), nameof(PublishedAt))]
+public class Article
+{
+    public Guid Id { get; set; }
+
+    [Bm25Text(Stemmer = Bm25Language.English, Fast = true)]
+    public string Title { get; set; }
+
+    [Bm25Text(Stemmer = Bm25Language.English, Record = Bm25Record.Position)]
+    public string Content { get; set; }
+
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Raw, Fast = true)]
+    public string Category { get; set; }
+
+    [Bm25Numeric(Fast = true)]
+    public int Rating { get; set; }
+
+    [Bm25DateTime(Fast = true)]
+    public DateTime PublishedAt { get; set; }
+}
+```
+
+| Attribute | Settings |
+|---|---|
+| `[Bm25Text]` | `Tokenizer`, `MinGram` / `MaxGram` / `PrefixOnly` (ngram), `RegexPattern` (regex), `Stemmer`, `StopwordsLanguage`, `Fast`, `Record`, `Indexed`, `Fieldnorms` |
+| `[Bm25Numeric]` | `Fast`, `Indexed` |
+| `[Bm25Boolean]` | `Fast`, `Indexed` |
+| `[Bm25DateTime]` | `Fast`, `Indexed` |
+| `[Bm25Json]` | same as `[Bm25Text]` plus `ExpandDots` |
+
+**`Bm25Tokenizer`** — `Default`, `Whitespace`, `Raw`, `Keyword`, `SourceCode`, `Icu`, `Ngram`, `Regex`, `ChineseCompatible`, `ChineseLindera`, `JapaneseLindera`, `KoreanLindera`, `Jieba`. `Ngram` requires `MinGram` and `MaxGram`; `Regex` requires `RegexPattern`. Other tokenizers take no parameters.
+
+**`Bm25Language`** — used by both `Stemmer` and `StopwordsLanguage`: `Arabic`, `Czech`, `Danish`, `Dutch`, `English`, `Finnish`, `French`, `German`, `Greek`, `Hungarian`, `Italian`, `Norwegian`, `Polish`, `Portuguese`, `Romanian`, `Russian`, `Spanish`, `Swedish`, `Tamil`, `Turkish`.
+
+**`Bm25Record`** — `Basic` (term + frequency), `Freq`, or `Position`. `Position` is required for phrase queries; the others use less disk.
+
+**`Fast`** stores the column in columnar format for sorting/faceting/aggregation. Required if you want `ORDER BY` on this column to use the index.
+
+A property may only have one `[Bm25*]` attribute, and that property must be listed in the entity's `[Bm25Index]` columns — orphan attributes throw at model-build time.
+
+### 4. Create a migration
 
 ```bash
 dotnet ef migrations add AddBm25Index
@@ -54,7 +101,7 @@ dotnet ef database update
 
 EF Core will generate the migration automatically, creating:
 - The `pg_search` PostgreSQL extension
-- A BM25 index on the specified columns with the correct `key_field` storage parameter
+- A BM25 index on the specified columns with the `key_field` storage parameter and per-column `text_fields` / `numeric_fields` / `boolean_fields` / `datetime_fields` / `json_fields` JSON derived from any `[Bm25Text]` / `[Bm25Numeric]` / etc. attributes
 
 ## Querying
 
@@ -442,42 +489,14 @@ The library hooks into EF Core's model finalization pipeline via `IConventionSet
 1. Scans entity types for `[Bm25Index]` attributes
 2. Creates database indexes with the `bm25` index method
 3. Sets the `key_field` storage parameter (required by pg_search)
-4. Registers the `pg_search` PostgreSQL extension
+4. Reads `[Bm25Text]` / `[Bm25Numeric]` / `[Bm25Boolean]` / `[Bm25DateTime]` / `[Bm25Json]` from the indexed properties and emits the corresponding `text_fields` / `numeric_fields` / `boolean_fields` / `datetime_fields` / `json_fields` JSON storage parameters
+5. Registers the `pg_search` PostgreSQL extension
 
 All of this is translated into standard EF Core migrations — no manual SQL required.
 
 ### Query translation
 
-LINQ methods on `EF.Functions` are translated to SQL via `IMethodCallTranslatorPlugin`:
-
-| C# Method | SQL |
-|-----------|-----|
-| `Matches(col, "q")` | `col \|\|\| 'q'` |
-| `MatchesAll(col, "q")` | `col &&& 'q'` |
-| `MatchesPhrase(col, "q")` | `col ### 'q'` |
-| `MatchesPhrase(col, "q", 2)` | `col ### 'q'::pdb.slop(2)` |
-| `MatchesTerm(col, "q")` | `col === 'q'` |
-| `MatchesTermSet(col, "a", "b")` | `col === ARRAY['a', 'b']` |
-| `MatchesFuzzy(col, "q", 2)` | `col \|\|\| 'q'::pdb.fuzzy(2)` |
-| `MatchesFuzzy(col, "q", 2, true, false)` | `col \|\|\| 'q'::pdb.fuzzy(2, true, false)` |
-| `MatchesAllFuzzy(col, "q", 2)` | `col &&& 'q'::pdb.fuzzy(2)` |
-| `MatchesTermFuzzy(col, "q", 1)` | `col === 'q'::pdb.fuzzy(1)` |
-| `MatchesBoosted(col, "q", 2.0)` | `col \|\|\| 'q'::pdb.boost(2)` |
-| `MatchesAllBoosted(col, "q", 2.0)` | `col &&& 'q'::pdb.boost(2)` |
-| `MatchesFuzzyBoosted(col, "q", 2, 2.0)` | `col \|\|\| 'q'::pdb.fuzzy(2)::pdb.boost(2)` |
-| `MatchesAllFuzzyBoosted(col, "q", 2, 2.0)` | `col &&& 'q'::pdb.fuzzy(2)::pdb.boost(2)` |
-| `Score(id)` | `pdb.score(id)` |
-| `Snippet(col)` | `pdb.snippet(col)` |
-| `Snippet(col, "<b>", "</b>", 100)` | `pdb.snippet(col, start_tag => '<b>', end_tag => '</b>', max_num_chars => 100)` |
-| `Snippets(col, 15, 5, 0)` | `pdb.snippets(col, max_num_chars => 15, "limit" => 5, "offset" => 0)` |
-| `Parse(id, "desc:shoes")` | `id @@@ pdb.parse('desc:shoes')` |
-| `Parse(id, "q", true, true)` | `id @@@ pdb.parse('q', lenient => true, conjunction_mode => true)` |
-| `Regex(col, "key.*")` | `col @@@ pdb.regex('key.*')` |
-| `PhrasePrefix(col, "running", "sh")` | `col @@@ pdb.phrase_prefix(ARRAY['running', 'sh'])` |
-| `PhrasePrefix(col, 10, "running", "sh")` | `col @@@ pdb.phrase_prefix(ARRAY['running', 'sh'], max_expansions => 10)` |
-| `MoreLikeThis(id, 3)` | `id @@@ pdb.more_like_this(3)` |
-| `MoreLikeThis(id, 3, "description")` | `id @@@ pdb.more_like_this(3, ARRAY['description'])` |
-| `JsonSearch(id, jsonQuery)` | `id @@@ 'jsonQuery'::pdb.query` |
+LINQ methods on `EF.Functions` are translated to SQL via `IMethodCallTranslatorPlugin`. The mapping for each method is shown alongside its example in the [Querying](#querying) section above.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds `[Bm25Text]`, `[Bm25Numeric]`, `[Bm25Boolean]`, `[Bm25DateTime]`, and `[Bm25Json]` property-level attributes that translate into the `text_fields` / `numeric_fields` / `boolean_fields` / `datetime_fields` / `json_fields` JSON storage parameters on the BM25 index.
- Full tokenizer coverage: `Default`, `Whitespace`, `Raw`, `Keyword`, `SourceCode`, `Icu`, `Ngram` (with `MinGram`/`MaxGram`/`PrefixOnly`), `Regex` (with `RegexPattern`), and CJK tokenizers. Stemmer/stopwords cover all 19 pg_search languages. `Record`, `Fast`, `Indexed`, `Fieldnorms`, and `ExpandDots` (json) are also exposed.
- 21 new tests assert against the generated migration SQL via `Database.GenerateCreateScript()`; existing 65 translation tests unchanged. All 86 pass on net8.0, net9.0, and net10.0.
- Bumps package version `0.1.1` -> `0.2.0`.

## Code changes

- `Bm25Tokenizer.cs`, `Bm25Language.cs`, `Bm25Record.cs` — new public enums, each with an `Unspecified = 0` sentinel so attribute properties can distinguish "not set" from a real value (C# attributes can't take nullable enum types).
- `Bm25TextAttribute.cs`, `Bm25NumericAttribute.cs`, `Bm25BooleanAttribute.cs`, `Bm25DateTimeAttribute.cs`, `Bm25JsonAttribute.cs` — new `[AttributeUsage(Property)]` types with the per-field-type settings.
- `Internal/Bm25EnumExtensions.cs` — `ToParadeDbString()` mapping each enum to pg_search's JSON string value.
- `Internal/Bm25StorageParameterBuilder.cs` — builds the `JsonObject` for each field-type group; performs tokenizer-param validation (`Ngram` requires `MinGram`/`MaxGram`; `Regex` requires `RegexPattern`; mismatches throw `InvalidOperationException`).
- `ParadeDbModelFinalizingConvention.cs` — extends the existing loop to walk each entity's `[Bm25Index]` columns, look up the per-property `[Bm25*]` attribute, group by field type, serialize to JSON, and attach via `Npgsql:StorageParameter:<group>` annotations. Adds orphan-attribute validation (a `[Bm25*]` property must live in the entity's `[Bm25Index]` columns).
- `Bm25IndexConfigurationTests.cs` — new test file. Each test uses a closed-generic `ConfigTestContext<TEntity>` so EF Core's per-context-type model cache produces a fresh model per test, then asserts on `ctx.Database.GenerateCreateScript()` output.
- `README.md` — new section "Setup → 3. (Optional) Configure per-column index settings" with attribute/enum reference. Removed the duplicate `### Query translation` table from `## How it works` (every row already shown inline in the relevant `## Querying` subsection).
- `Directory.Build.props` — version 0.1.1 -> 0.2.0.