### PR TITLE
feat(tests): add ParadeDB integration tests + fix JsonSearch cast

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/AdvancedQueryTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/AdvancedQueryTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class AdvancedQueryTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task Parse_TantivySyntax_FiltersByField() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var results = await ctx.Articles
+            .Where(a => EF.Functions.Parse(a.Id, "title:transformer"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(results, t => t == "Transformer architectures");
+        Assert.DoesNotContain(results, t => t == "Cooking pasta perfectly");
+    }
+
+    [Fact]
+    public async Task MoreLikeThis_ExecutesAndReturnsRelatedArticle() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var seed = await ctx.Articles.SingleAsync(a => a.Title == "Introduction to neural networks");
+
+        var related = await ctx.Articles
+            .Where(a => EF.Functions.MoreLikeThis(a.Id, seed.Id))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // With only a handful of seeded documents, pg_search's similarity threshold is weak,
+        // so we don't assert what gets *excluded* — only that the function returns and the
+        // most-similar candidate (Transformers article) is present.
+        Assert.Contains(related, t => t == "Transformer architectures");
+    }
+
+    [Fact]
+    public async Task JsonSearch_BooleanQuery_CombinesParseAndTerm() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Boolean(b => b.Must(
+            ParadeDbJsonQuery.Parse("neural"),
+            ParadeDbJsonQuery.Term("category", "machine-learning")));
+
+        var results = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(results, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(results, t => t == "Quantum computing fundamentals");
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/BasicSearchTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/BasicSearchTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class BasicSearchTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task Matches_OrOperator_ReturnsMatchingDocuments() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var results = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural networks"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(results, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(results, t => t == "Cooking pasta perfectly");
+    }
+
+    [Fact]
+    public async Task MatchesAll_AndOperator_RequiresAllTerms() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var results = await ctx.Articles
+            .Where(a => EF.Functions.MatchesAll(a.Content, "attention transformers"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Single(results);
+        Assert.Equal("Transformer architectures", results[0]);
+    }
+
+    [Fact]
+    public async Task MatchesPhrase_RequiresExactOrder() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var withExactPhrase = await ctx.Articles
+            .Where(a => EF.Functions.MatchesPhrase(a.Content, "neural networks"))
+            .CountAsync();
+        var withReversedPhrase = await ctx.Articles
+            .Where(a => EF.Functions.MatchesPhrase(a.Content, "networks neural"))
+            .CountAsync();
+
+        Assert.Equal(1, withExactPhrase);
+        Assert.Equal(0, withReversedPhrase);
+    }
+
+    [Fact]
+    public async Task MatchesFuzzy_ToleratesTypos() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var results = await ctx.Articles
+            .Where(a => EF.Functions.MatchesFuzzy(a.Content, "nueral", 2))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(results, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task MatchesTerm_RequiresExactToken() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTerm(a.Content, "gpus"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>EF1001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.ParadeDB.EntityFrameworkCore\Equibles.ParadeDB.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IndexConfigurationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IndexConfigurationTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class IndexConfigurationTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task PgSearchExtension_IsInstalled() {
+        await using var conn = new NpgsqlConnection(fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT 1 FROM pg_extension WHERE extname = 'pg_search'";
+
+        var result = await cmd.ExecuteScalarAsync();
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Bm25Index_IsCreatedWithStorageParameters() {
+        await using var conn = new NpgsqlConnection(fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT indexdef FROM pg_indexes
+            WHERE tablename = 'articles' AND indexname LIKE 'IX_%'
+            """;
+
+        var indexDef = (string?)await cmd.ExecuteScalarAsync();
+
+        Assert.NotNull(indexDef);
+        Assert.Contains("USING bm25", indexDef);
+        Assert.Contains("key_field=", indexDef);
+        Assert.Contains("text_fields=", indexDef);
+        Assert.Contains("numeric_fields=", indexDef);
+    }
+
+    [Fact]
+    public async Task EnglishStemmer_MatchesWordVariants() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "run"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.Contains(hits, t => t == "Transformer architectures");
+    }
+
+    [Fact]
+    public async Task RawTokenizer_KeepsExactCategoryValue() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var exactHits = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTerm(a.Category, "machine-learning"))
+            .CountAsync();
+        var tokenizedAttempt = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTerm(a.Category, "machine"))
+            .CountAsync();
+
+        Assert.Equal(2, exactHits);
+        Assert.Equal(0, tokenizedAttempt);
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IntegrationDbContext.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IntegrationDbContext.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+public sealed class IntegrationDbContext(DbContextOptions<IntegrationDbContext> options) : DbContext(options) {
+    public DbSet<Article> Articles => Set<Article>();
+}
+
+[Table("articles")]
+[Bm25Index(nameof(Id), nameof(Title), nameof(Content), nameof(Category), nameof(Rating))]
+public sealed class Article {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("title")]
+    [Bm25Text(Stemmer = Bm25Language.English, Fast = true)]
+    public string Title { get; set; } = null!;
+
+    [Column("content")]
+    [Bm25Text(Stemmer = Bm25Language.English, Record = Bm25Record.Position)]
+    public string Content { get; set; } = null!;
+
+    [Column("category")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Raw, Fast = true)]
+    public string Category { get; set; } = null!;
+
+    [Column("rating")]
+    [Bm25Numeric(Fast = true)]
+    public int Rating { get; set; }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+public sealed class ParadeDbFixture : IAsyncLifetime {
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("paradedb/paradedb:latest")
+        .WithDatabase("paradedb_test")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    public string ConnectionString { get; private set; } = default!;
+
+    public async Task InitializeAsync() {
+        await _container.StartAsync();
+        ConnectionString = _container.GetConnectionString();
+
+        await using var ctx = CreateDbContext();
+        await ctx.Database.EnsureCreatedAsync();
+        await SeedAsync(ctx);
+    }
+
+    public async Task DisposeAsync() {
+        await _container.DisposeAsync();
+    }
+
+    public IntegrationDbContext CreateDbContext() => new(
+        new DbContextOptionsBuilder<IntegrationDbContext>()
+            .UseNpgsql(ConnectionString, n => n.UseParadeDb())
+            .Options);
+
+    private static async Task SeedAsync(IntegrationDbContext ctx) {
+        ctx.Articles.AddRange(
+            new Article {
+                Title = "Introduction to neural networks",
+                Content = "Deep learning models running on GPUs revolutionize machine learning. Neural networks are layered.",
+                Category = "machine-learning",
+                Rating = 5,
+            },
+            new Article {
+                Title = "Transformer architectures",
+                Content = "The attention mechanism powers modern language models. Transformers run efficiently on TPUs.",
+                Category = "machine-learning",
+                Rating = 4,
+            },
+            new Article {
+                Title = "Quantum computing fundamentals",
+                Content = "Qubits and entanglement enable parallel computation beyond classical bits.",
+                Category = "physics",
+                Rating = 3,
+            },
+            new Article {
+                Title = "Cooking pasta perfectly",
+                Content = "Salt the water generously and cook the pasta until al dente. Taste it as you go.",
+                Category = "cooking",
+                Rating = 5,
+            });
+        await ctx.SaveChangesAsync();
+    }
+}
+
+[CollectionDefinition(nameof(ParadeDbCollection))]
+public class ParadeDbCollection : ICollectionFixture<ParadeDbFixture> { }

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ScoringAndSnippetTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ScoringAndSnippetTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class ScoringAndSnippetTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task Score_OrdersByRelevance() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var ranked = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural networks"))
+            .Select(a => new { a.Title, Score = EF.Functions.Score(a.Id) })
+            .OrderByDescending(x => x.Score)
+            .ToListAsync();
+
+        Assert.NotEmpty(ranked);
+        Assert.True(ranked[0].Score > 0);
+        if (ranked.Count > 1) {
+            Assert.True(ranked[0].Score >= ranked[1].Score, "Results should be ordered by descending score.");
+        }
+    }
+
+    [Fact]
+    public async Task Snippet_HighlightsMatchedTerms() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var snippets = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural networks"))
+            .Select(a => EF.Functions.Snippet(a.Content, "<mark>", "</mark>", 100))
+            .ToListAsync();
+
+        Assert.NotEmpty(snippets);
+        Assert.Contains(snippets, s => s != null && s.Contains("<mark>") && s.Contains("</mark>"));
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
@@ -238,7 +238,7 @@ public class QueryTranslationTests : IDisposable {
         var json = ParadeDbJsonQuery.Parse("revenue growth").ToJson();
         var sql = Sql(_db.Chunks.Where(c => EF.Functions.JsonSearch(c.Id, json)));
         Assert.Contains("@@@", sql);
-        Assert.Contains("::pdb.query", sql);
+        Assert.Contains("::jsonb", sql);
     }
 
     [Fact]
@@ -249,7 +249,7 @@ public class QueryTranslationTests : IDisposable {
                 ParadeDbJsonQuery.Term("DocumentType", 10)));
         var sql = Sql(_db.Chunks.Where(c => EF.Functions.JsonSearch(c.Id, query.ToJson())));
         Assert.Contains("@@@", sql);
-        Assert.Contains("::pdb.query", sql);
+        Assert.Contains("::jsonb", sql);
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class QueryTranslationTests : IDisposable {
             .Where(c => EF.Functions.JsonSearch(c.Id, json))
             .OrderByDescending(c => EF.Functions.Score(c.Id)));
         Assert.Contains("@@@", sql);
-        Assert.Contains("::pdb.query", sql);
+        Assert.Contains("::jsonb", sql);
         Assert.Contains("pdb.score(", sql);
         Assert.Contains("ORDER BY", sql);
     }
@@ -280,7 +280,7 @@ public class QueryTranslationTests : IDisposable {
         var sql = Sql(_db.Chunks
             .Where(c => EF.Functions.JsonSearch(c.Id, json) && c.DocumentType > 5));
         Assert.Contains("@@@", sql);
-        Assert.Contains("::pdb.query", sql);
+        Assert.Contains("::jsonb", sql);
         Assert.Contains(">", sql);
     }
 
@@ -290,7 +290,7 @@ public class QueryTranslationTests : IDisposable {
         var sqlExt = Sql(_db.Chunks.JsonSearch(c => c.Id, query));
         var sqlDirect = Sql(_db.Chunks.Where(c => EF.Functions.JsonSearch(c.Id, query.ToJson())));
         Assert.Contains("@@@", sqlExt);
-        Assert.Contains("::pdb.query", sqlExt);
+        Assert.Contains("::jsonb", sqlExt);
         Assert.Contains("@@@", sqlDirect);
     }
 
@@ -301,7 +301,7 @@ public class QueryTranslationTests : IDisposable {
                 ParadeDbJsonQuery.Parse("revenue growth"),
                 ParadeDbJsonQuery.Term("DocumentType", 10))));
         Assert.Contains("@@@", sql);
-        Assert.Contains("::pdb.query", sql);
+        Assert.Contains("::jsonb", sql);
     }
 
     // ── Combining with LINQ ───────────────────────────────────────────

--- a/Equibles.ParadeDB.EntityFrameworkCore.slnx
+++ b/Equibles.ParadeDB.EntityFrameworkCore.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="Equibles.ParadeDB.EntityFrameworkCore/Equibles.ParadeDB.EntityFrameworkCore.csproj" />
   <Project Path="Equibles.ParadeDB.EntityFrameworkCore.Tests/Equibles.ParadeDB.EntityFrameworkCore.Tests.csproj" />
+  <Project Path="Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj" />
 </Solution>

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
@@ -218,7 +218,7 @@ public static class ParadeDbFunctions {
     // ── JSON Query Search ────────────────────────────────────────────
 
     /// <summary>
-    /// JSON query search. Translates to: keyField @@@ 'jsonQuery'::pdb.query.
+    /// JSON query search. Translates to: keyField @@@ 'jsonQuery'::jsonb.
     /// Executes a structured query using ParadeDB's JSON query syntax.
     /// Build the query string using <see cref="ParadeDbJsonQuery"/>.
     /// </summary>

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
@@ -268,7 +268,7 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
         if (method == JsonSearchMethod) {
             var jsonExpr = Map(arguments[2]);
             var castExpr = new ParadeDbModifiedQueryExpression(
-                jsonExpr, "::pdb.query", jsonExpr.Type, jsonExpr.TypeMapping);
+                jsonExpr, "::jsonb", jsonExpr.Type, jsonExpr.TypeMapping);
             return MakeBinaryBool(arguments[1], "@@@", castExpr);
         }
 

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbSearchExtensions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbSearchExtensions.cs
@@ -16,7 +16,7 @@ public static class ParadeDbSearchExtensions {
 
     /// <summary>
     /// Adds a WHERE clause with a ParadeDB boolean JSON query built inline.
-    /// Translates to: <c>keyField @@@ 'json'::pdb.query</c>.
+    /// Translates to: <c>keyField @@@ 'json'::jsonb</c>.
     /// </summary>
     public static IQueryable<T> JsonSearch<T>(this IQueryable<T> source,
         Expression<Func<T, object>> keyField, Action<ParadeDbBooleanQuery> configure) where T : class {
@@ -25,7 +25,7 @@ public static class ParadeDbSearchExtensions {
 
     /// <summary>
     /// Adds a WHERE clause with a ParadeDB JSON query.
-    /// Translates to: <c>keyField @@@ 'json'::pdb.query</c>.
+    /// Translates to: <c>keyField @@@ 'json'::jsonb</c>.
     /// </summary>
     public static IQueryable<T> JsonSearch<T>(this IQueryable<T> source,
         Expression<Func<T, object>> keyField, ParadeDbJsonQuery query) where T : class {

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ public class Article
 
 A property may only have one `[Bm25*]` attribute, and that property must be listed in the entity's `[Bm25Index]` columns — orphan attributes throw at model-build time.
 
+> **Column naming note.** Some pg_search functions (`pdb.more_like_this`, JSON `term` filters via `JsonSearch`) generate internal SQL that references columns *unquoted*, so PostgreSQL folds them to lowercase. If your entity's properties map to PascalCase columns (the EF Core default), those functions will fail with `column "id" does not exist`. The simplest fix is to map columns to `snake_case` — either with the [EFCore.NamingConventions](https://github.com/efcore/EFCore.NamingConventions) package (`npgsql.UseSnakeCaseNamingConvention()`) or explicit `[Column("snake_case")]` per property. Basic search operators (`Matches`, `MatchesPhrase`, `MatchesFuzzy`, `Score`, `Snippet`, `Parse`, `Regex`, `PhrasePrefix`) work with PascalCase columns since they reference the column directly in the LINQ expression.
+
 ### 4. Create a migration
 
 ```bash
@@ -390,7 +392,7 @@ SELECT * FROM "Articles" WHERE "Id" @@@ pdb.more_like_this(3, ARRAY['description
 
 ### JSON Query Search
 
-For complex queries combining full-text search with term filters, use `ParadeDbJsonQuery` to build structured JSON queries. This translates to the `@@@` operator with `::pdb.query` cast.
+For complex queries combining full-text search with term filters, use `ParadeDbJsonQuery` to build structured JSON queries. This translates to the `@@@` operator with `::jsonb` cast.
 
 ```csharp
 // Build a boolean query combining parse + term filters
@@ -432,7 +434,7 @@ WHERE "Id" @@@ '{"boolean":{"must":[
     {"parse":{"query_string":"revenue growth"}},
     {"term":{"field":"DocumentId","value":"..."}},
     {"term":{"field":"DocumentType","value":10}}
-]}}'::pdb.query
+]}}'::jsonb
 ORDER BY pdb.score("Id") DESC
 LIMIT 5
 ```


### PR DESCRIPTION
## Summary

- Adds `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests` — a new test project that spins up the `paradedb/paradedb` container via Testcontainers and runs 14 end-to-end tests against a real Postgres + pg_search. Tests cover index creation, all major search operators, scoring, snippets, parse-syntax queries, MoreLikeThis, JsonSearch, English stemming, and Raw-tokenizer exact matching.
- Fixes a library bug surfaced by the integration suite: `JsonSearch` was emitting `'json'::pdb.query` but current ParadeDB only accepts `'json'::jsonb`. Updated the translator, doc comments, README example, and unit-test assertions.
- Documents a ParadeDB constraint discovered during testing: `pdb.more_like_this` and JSON `term` filters reference columns via *unquoted* identifiers internally, so they require lowercase column names. README now recommends `EFCore.NamingConventions` snake_case mapping or per-property `[Column("snake_case")]` for users of those features. Other search operators work with PascalCase columns unchanged.
- Bumps package version `0.2.0` -> `0.2.1`.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/*` — new test project. `ParadeDbFixture` (xUnit `ICollectionFixture`) starts a single `paradedb/paradedb:latest` container per test run, calls `EnsureCreatedAsync()` against the model, and seeds 4 articles. `IntegrationDbContext` + the test `Article` entity demonstrate `[Bm25Text]` with English stemmer + position recording, `[Bm25Text]` with `Bm25Tokenizer.Raw`, and `[Bm25Numeric]`. Four test files split by concern: `BasicSearchTests`, `ScoringAndSnippetTests`, `AdvancedQueryTests`, `IndexConfigurationTests`.
- `ParadeDbMethodCallTranslator.cs` — `JsonSearch` translation: `"::pdb.query"` -> `"::jsonb"`.
- `ParadeDbFunctions.cs`, `ParadeDbSearchExtensions.cs` — doc comment cast updated to `::jsonb`.
- `QueryTranslationTests.cs` — six assertions updated to expect `::jsonb`; method renamed `JsonSearch_generates_at_operator_with_pdb_query_cast` -> `..._with_jsonb_cast`.
- `README.md` — `JsonSearch` section now describes the `::jsonb` cast; new "Column naming note" paragraph documents the lowercase-column requirement for `MoreLikeThis` / JSON `term` filters and points at `EFCore.NamingConventions` as the recommended fix.
- `Equibles.ParadeDB.EntityFrameworkCore.slnx` — adds the new integration test project to the solution.
- `Directory.Build.props` — version `0.2.0` -> `0.2.1`.

## Test results

- Unit tests: 86 pass on `net8.0`, `net9.0`, and `net10.0` (the `::jsonb` change kept them all green).
- Integration tests: 14 pass on `net10.0` against `paradedb/paradedb:latest`.

Integration tests need Docker available; they're net10-only because the goal is to validate end-to-end behaviour against a real database, not multi-targeting (which the existing unit suite already covers).