### PR TITLE
test: expand integration + unit coverage; fix Snippets return type and ngram emission

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/FieldTypeTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/FieldTypeTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class FieldTypeTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task Bm25Boolean_IndexedFastColumn_FiltersByValue() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var inStockNames = await ctx.Products
+            .Where(p => EF.Functions.Matches(p.Name, "keyboard"))
+            .Where(p => p.InStock)
+            .Select(p => p.Name)
+            .ToListAsync();
+        var outOfStockNames = await ctx.Products
+            .Where(p => EF.Functions.Matches(p.Name, "keyboard"))
+            .Where(p => !p.InStock)
+            .Select(p => p.Name)
+            .ToListAsync();
+
+        Assert.DoesNotContain(inStockNames, n => n == "Mechanical keyboard");
+        Assert.Contains(outOfStockNames, n => n == "Mechanical keyboard");
+    }
+
+    [Fact]
+    public async Task Bm25DateTime_FastColumn_SupportsRangeFilter() {
+        await using var ctx = fixture.CreateDbContext();
+        var cutoff = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var recent = await ctx.Products
+            .Where(p => EF.Functions.Matches(p.Name, "laptop OR mouse OR keyboard"))
+            .Where(p => p.ReleasedAt >= cutoff)
+            .Select(p => p.Name)
+            .ToListAsync();
+
+        Assert.Contains(recent, n => n == "Ultra book laptop");
+        Assert.Contains(recent, n => n == "Wireless mouse");
+        Assert.DoesNotContain(recent, n => n == "Mechanical keyboard");
+    }
+
+    [Fact]
+    public async Task Bm25Json_WithExpandDots_IndexesJsonField() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Products
+            .Where(p => EF.Functions.Matches(p.Name, "laptop OR mouse OR keyboard"))
+            .Select(p => p.Name)
+            .ToListAsync();
+
+        Assert.Equal(3, hits.Count);
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IntegrationDbContext.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IntegrationDbContext.cs
@@ -5,6 +5,13 @@ namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
 
 public sealed class IntegrationDbContext(DbContextOptions<IntegrationDbContext> options) : DbContext(options) {
     public DbSet<Article> Articles => Set<Article>();
+    public DbSet<Product> Products => Set<Product>();
+    public DbSet<KeywordRecord> KeywordRecords => Set<KeywordRecord>();
+    public DbSet<NgramRecord> NgramRecords => Set<NgramRecord>();
+    public DbSet<IcuRecord> IcuRecords => Set<IcuRecord>();
+    public DbSet<SourceCodeRecord> SourceCodeRecords => Set<SourceCodeRecord>();
+    public DbSet<RegexRecord> RegexRecords => Set<RegexRecord>();
+    public DbSet<GermanArticle> GermanArticles => Set<GermanArticle>();
 }
 
 [Table("articles")]
@@ -28,4 +35,93 @@ public sealed class Article {
     [Column("rating")]
     [Bm25Numeric(Fast = true)]
     public int Rating { get; set; }
+}
+
+[Table("products")]
+[Bm25Index(nameof(Id), nameof(Name), nameof(InStock), nameof(ReleasedAt), nameof(Specs))]
+public sealed class Product {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("name")]
+    [Bm25Text(Stemmer = Bm25Language.English, Fast = true)]
+    public string Name { get; set; } = null!;
+
+    [Column("in_stock")]
+    [Bm25Boolean(Fast = true)]
+    public bool InStock { get; set; }
+
+    [Column("released_at")]
+    [Bm25DateTime(Fast = true)]
+    public DateTime ReleasedAt { get; set; }
+
+    [Column("specs", TypeName = "jsonb")]
+    [Bm25Json(ExpandDots = true)]
+    public string Specs { get; set; } = null!;
+}
+
+[Table("keyword_records")]
+[Bm25Index(nameof(Id), nameof(Code))]
+public sealed class KeywordRecord {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("code")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Keyword)]
+    public string Code { get; set; } = null!;
+}
+
+[Table("ngram_records")]
+[Bm25Index(nameof(Id), nameof(Body))]
+public sealed class NgramRecord {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("body")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Ngram, MinGram = 3, MaxGram = 5)]
+    public string Body { get; set; } = null!;
+}
+
+[Table("icu_records")]
+[Bm25Index(nameof(Id), nameof(Body))]
+public sealed class IcuRecord {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("body")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Icu)]
+    public string Body { get; set; } = null!;
+}
+
+[Table("source_code_records")]
+[Bm25Index(nameof(Id), nameof(Snippet))]
+public sealed class SourceCodeRecord {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("snippet")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.SourceCode)]
+    public string Snippet { get; set; } = null!;
+}
+
+[Table("regex_records")]
+[Bm25Index(nameof(Id), nameof(Body))]
+public sealed class RegexRecord {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("body")]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Regex, RegexPattern = "\\w+")]
+    public string Body { get; set; } = null!;
+}
+
+[Table("german_articles")]
+[Bm25Index(nameof(Id), nameof(Content))]
+public sealed class GermanArticle {
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("content")]
+    [Bm25Text(Stemmer = Bm25Language.German)]
+    public string Content { get; set; } = null!;
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonQueryTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonQueryTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonQueryTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task JsonSearch_NumericRange_FiltersByRating() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Range("rating", lowerBound: 4, upperBound: 5,
+            lowerInclusive: true, upperInclusive: true);
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Transformer architectures");
+        Assert.DoesNotContain(hits, t => t == "Quantum computing fundamentals");
+    }
+
+    [Fact]
+    public async Task JsonSearch_Should_OrSemantics() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Boolean(b => b.Should(
+            ParadeDbJsonQuery.Term("category", "cooking"),
+            ParadeDbJsonQuery.Term("category", "physics")));
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Cooking pasta perfectly");
+        Assert.Contains(hits, t => t == "Quantum computing fundamentals");
+        Assert.DoesNotContain(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task JsonSearch_MustNot_ExcludesMatchingDocs() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Boolean(b => b
+            .Must(ParadeDbJsonQuery.All())
+            .MustNot(ParadeDbJsonQuery.Term("category", "cooking")));
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.DoesNotContain(hits, t => t == "Cooking pasta perfectly");
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task JsonSearch_InlineBuilder_OverloadWorks() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, b => b
+                .Must(
+                    ParadeDbJsonQuery.Parse("neural"),
+                    ParadeDbJsonQuery.Term("category", "machine-learning")))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
@@ -57,6 +57,51 @@ public sealed class ParadeDbFixture : IAsyncLifetime {
                 Category = "cooking",
                 Rating = 5,
             });
+
+        ctx.Products.AddRange(
+            new Product {
+                Name = "Ultra book laptop",
+                InStock = true,
+                ReleasedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                Specs = """{"weight": 1200, "color": "silver"}""",
+            },
+            new Product {
+                Name = "Mechanical keyboard",
+                InStock = false,
+                ReleasedAt = new DateTime(2023, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+                Specs = """{"weight": 900, "color": "black"}""",
+            },
+            new Product {
+                Name = "Wireless mouse",
+                InStock = true,
+                ReleasedAt = new DateTime(2024, 11, 20, 0, 0, 0, DateTimeKind.Utc),
+                Specs = """{"weight": 80, "color": "white"}""",
+            });
+
+        ctx.KeywordRecords.AddRange(
+            new KeywordRecord { Code = "ABC-123" },
+            new KeywordRecord { Code = "XYZ-789" });
+
+        ctx.NgramRecords.AddRange(
+            new NgramRecord { Body = "supercalifragilistic" },
+            new NgramRecord { Body = "ordinary text" });
+
+        ctx.IcuRecords.AddRange(
+            new IcuRecord { Body = "Café résumé naïve" },
+            new IcuRecord { Body = "Plain ASCII text" });
+
+        ctx.SourceCodeRecords.AddRange(
+            new SourceCodeRecord { Snippet = "GetUserById" },
+            new SourceCodeRecord { Snippet = "SaveChangesAsync" });
+
+        ctx.RegexRecords.AddRange(
+            new RegexRecord { Body = "alpha beta gamma" },
+            new RegexRecord { Body = "delta epsilon" });
+
+        ctx.GermanArticles.AddRange(
+            new GermanArticle { Content = "Die Häuser sind groß und schön." },
+            new GermanArticle { Content = "Der Mann läuft schnell." });
+
         await ctx.SaveChangesAsync();
     }
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SearchApiTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SearchApiTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class SearchApiTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task MatchesBoosted_RaisesScoreOfBoostedTerm() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var withBoost = await ctx.Articles
+            .Where(a => EF.Functions.MatchesBoosted(a.Content, "neural", 5.0))
+            .Select(a => new { a.Title, Score = EF.Functions.Score(a.Id) })
+            .OrderByDescending(a => a.Score)
+            .ToListAsync();
+
+        Assert.NotEmpty(withBoost);
+        Assert.True(withBoost[0].Score > 1.0,
+            $"Boosted score should be amplified above default 1.0; was {withBoost[0].Score}.");
+    }
+
+    [Fact]
+    public async Task MatchesTermSet_MatchesAnyToken() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTermSet(a.Content, "gpus", "tpus"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.Contains(hits, t => t == "Transformer architectures");
+    }
+
+    [Fact]
+    public async Task MatchesPhraseWithSlop_AllowsWordsBetweenTerms() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var exact = await ctx.Articles
+            .Where(a => EF.Functions.MatchesPhrase(a.Content, "deep models"))
+            .CountAsync();
+        var withSlop = await ctx.Articles
+            .Where(a => EF.Functions.MatchesPhrase(a.Content, "deep models", 2))
+            .CountAsync();
+
+        Assert.Equal(0, exact);
+        Assert.True(withSlop >= 1, "Slop 2 should match 'Deep learning models'.");
+    }
+
+    [Fact]
+    public async Task MatchesAllFuzzy_AndOperatorToleratesTypos() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.MatchesAllFuzzy(a.Content, "nueral netwroks", 2))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task MatchesTermFuzzy_SingleTermToleratesTypos() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTermFuzzy(a.Content, "neurla", 2))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task Snippets_ReturnsHighlightedExcerptArray() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var snippets = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural"))
+            .Select(a => EF.Functions.Snippets(a.Content, 80, 3, 0))
+            .ToListAsync();
+
+        Assert.NotEmpty(snippets);
+        Assert.Contains(snippets, arr => arr.Any(s => s.Contains("<b>") && s.Contains("</b>")));
+    }
+
+    [Fact]
+    public async Task Regex_FindsTokensMatchingPattern() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.Regex(a.Content, "neur.*"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task PhrasePrefix_MatchesPartialLastWord() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.PhrasePrefix(a.Content, "neural", "net"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task Parse_LenientMode_IgnoresMalformedSyntax() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // Trailing operator would normally throw; lenient + conjunctionMode lets it parse.
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.Parse(a.Id, "neural networks", lenient: true, conjunctionMode: true))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+    }
+
+    [Fact]
+    public async Task ComposedLinq_SearchPlusWhereAndProjection_Works() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var top = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural networks") && a.Rating >= 4)
+            .Select(a => new {
+                a.Title,
+                Snippet = EF.Functions.Snippet(a.Content, "<mark>", "</mark>", 60),
+                Score = EF.Functions.Score(a.Id),
+            })
+            .OrderByDescending(x => x.Score)
+            .Take(5)
+            .ToListAsync();
+
+        Assert.NotEmpty(top);
+        Assert.All(top, x => Assert.False(string.IsNullOrEmpty(x.Title)));
+        Assert.All(top, x => Assert.True(x.Score > 0));
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/TokenizerTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/TokenizerTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class TokenizerTests(ParadeDbFixture fixture) {
+    [Fact]
+    public async Task KeywordTokenizer_TreatsCodeAsSingleToken() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.KeywordRecords
+            .Where(k => EF.Functions.MatchesTerm(k.Code, "ABC-123"))
+            .Select(k => k.Code)
+            .ToListAsync();
+
+        Assert.Single(hits);
+        Assert.Equal("ABC-123", hits[0]);
+    }
+
+    [Fact]
+    public async Task NgramTokenizer_MatchesSubstring() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.NgramRecords
+            .Where(n => EF.Functions.MatchesTerm(n.Body, "frag"))
+            .Select(n => n.Body)
+            .ToListAsync();
+
+        Assert.Contains(hits, b => b == "supercalifragilistic");
+    }
+
+    [Fact]
+    public async Task IcuTokenizer_HandlesUnicodeText() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.IcuRecords
+            .Where(i => EF.Functions.Matches(i.Body, "café"))
+            .Select(i => i.Body)
+            .ToListAsync();
+
+        Assert.Contains(hits, b => b.Contains("Café"));
+    }
+
+    [Fact]
+    public async Task SourceCodeTokenizer_SplitsCamelCase() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.SourceCodeRecords
+            .Where(s => EF.Functions.Matches(s.Snippet, "user"))
+            .Select(s => s.Snippet)
+            .ToListAsync();
+
+        Assert.Contains(hits, s => s == "GetUserById");
+    }
+
+    [Fact]
+    public async Task RegexTokenizer_TokenizesByPattern() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.RegexRecords
+            .Where(r => EF.Functions.Matches(r.Body, "alpha"))
+            .Select(r => r.Body)
+            .ToListAsync();
+
+        Assert.Contains(hits, b => b == "alpha beta gamma");
+    }
+
+    [Fact]
+    public async Task GermanStemmer_MatchesGermanWordVariants() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // 'Häuser' stems to a German root; 'Haus' should match via the same stem.
+        var hits = await ctx.GermanArticles
+            .Where(g => EF.Functions.Matches(g.Content, "Haus"))
+            .Select(g => g.Content)
+            .ToListAsync();
+
+        Assert.Contains(hits, c => c.Contains("Häuser"));
+    }
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
@@ -38,9 +38,9 @@ public class Bm25IndexConfigurationTests {
     }
 
     [Fact]
-    public void Bm25Text_WithNgramTokenizer_EmitsMinMaxGram() {
+    public void Bm25Text_WithNgramTokenizer_EmitsMinMaxGramAndPrefixOnly() {
         var sql = GetCreateScript<NgramEntity>();
-        Assert.Contains("""text_fields='{"Content":{"tokenizer":{"type":"ngram","min_gram":2,"max_gram":4}}}'""", sql);
+        Assert.Contains("""text_fields='{"Content":{"tokenizer":{"type":"ngram","min_gram":2,"max_gram":4,"prefix_only":false}}}'""", sql);
     }
 
     [Fact]

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.Tests;
+
+public class ExpressionTests {
+    private static SqlExpression Stub(string token) => new StubSqlExpression(token);
+
+    private sealed class StubSqlExpression : SqlExpression {
+        private readonly string _token;
+        public StubSqlExpression(string token) : base(typeof(string), new FakeTypeMapping()) {
+            _token = token;
+        }
+        protected override void Print(ExpressionPrinter expressionPrinter) => expressionPrinter.Append(_token);
+        public override bool Equals(object obj) => obj is StubSqlExpression other && other._token == _token;
+        public override int GetHashCode() => _token.GetHashCode();
+#if NET9_0_OR_GREATER
+        public override System.Linq.Expressions.Expression Quote() => throw new NotSupportedException();
+#endif
+    }
+
+    private sealed class FakeTypeMapping : RelationalTypeMapping {
+        public FakeTypeMapping() : base("text", typeof(string)) { }
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters) => this;
+    }
+
+    [Fact]
+    public void ModifiedQueryExpression_Equals_ReturnsTrueForSameInnerAndSuffix() {
+        var inner = Stub("hello");
+        var a = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+        var b = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void ModifiedQueryExpression_Equals_ReturnsFalseForDifferentSuffix() {
+        var inner = Stub("hello");
+        var a = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+        var b = new ParadeDbModifiedQueryExpression(inner, "::pdb.boost(2)", typeof(string), inner.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void ModifiedQueryExpression_Equals_ReturnsFalseForUnrelatedType() {
+        var inner = Stub("hello");
+        var a = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+
+        Assert.False(a.Equals("not an expression"));
+    }
+
+    [Fact]
+    public void ModifiedQueryExpression_Print_EmitsInnerThenSuffix() {
+        var inner = Stub("hello");
+        var expr = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+
+        var printer = new ExpressionPrinter();
+        printer.Visit(expr);
+
+        Assert.Contains("::pdb.fuzzy(2)", printer.ToString());
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsTrueForSameStructure() {
+        var arg = Stub("c");
+        var named = Stub("<b>");
+
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", named)], typeof(string), arg.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", named)], typeof(string), arg.TypeMapping);
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentFunctionName() {
+        var arg = Stub("c");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg], [], typeof(string), arg.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippets", [arg], [], typeof(string), arg.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentNamedArgName() {
+        var arg = Stub("c");
+        var v1 = Stub("<b>");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", v1)], typeof(string), arg.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("end_tag", v1)], typeof(string), arg.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Print_EmitsPositionalAndNamedArgs() {
+        var positional = Stub("c");
+        var named = Stub("<b>");
+        var expr = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [positional], [("start_tag", named)], typeof(string), positional.TypeMapping);
+
+        var printer = new ExpressionPrinter();
+        printer.Visit(expr);
+        var output = printer.ToString();
+
+        Assert.Contains("pdb.snippet(", output);
+        Assert.Contains("start_tag => ", output);
+        Assert.Contains(")", output);
+    }
+
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void ModifiedQueryExpression_Quote_Throws() {
+        var inner = Stub("hello");
+        var expr = new ParadeDbModifiedQueryExpression(inner, "::pdb.fuzzy(2)", typeof(string), inner.TypeMapping);
+
+        Assert.Throws<NotSupportedException>(() => expr.Quote());
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Quote_Throws() {
+        var arg = Stub("c");
+        var expr = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg], [], typeof(string), arg.TypeMapping);
+
+        Assert.Throws<NotSupportedException>(() => expr.Quote());
+    }
+#endif
+}

--- a/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25StorageParameterBuilder.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/Internal/Bm25StorageParameterBuilder.cs
@@ -75,7 +75,7 @@ internal static class Bm25StorageParameterBuilder {
         if (effectiveTokenizer == Bm25Tokenizer.Ngram) {
             tok["min_gram"] = minGram;
             tok["max_gram"] = maxGram;
-            if (prefixOnly) tok["prefix_only"] = true;
+            tok["prefix_only"] = prefixOnly;
         }
         if (effectiveTokenizer == Bm25Tokenizer.Regex) {
             tok["pattern"] = regexPattern;

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
@@ -156,8 +156,9 @@ public static class ParadeDbFunctions {
 
     /// <summary>
     /// Multiple snippets. Translates to: pdb.snippets(column, max_num_chars => N, "limit" => L, "offset" => O).
+    /// Returns a text[] of highlighted excerpts.
     /// </summary>
-    public static string Snippets(this DbFunctions _, string column, int maxNumChars, int limit, int offset)
+    public static string[] Snippets(this DbFunctions _, string column, int maxNumChars, int limit, int offset)
         => throw new InvalidOperationException(OnlyInLinq);
 
     // ── Parse Query (Tantivy Syntax) ──────────────────────────────────

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
@@ -204,7 +204,7 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
                     ("\"limit\"", Map(arguments[3])),
                     ("\"offset\"", Map(arguments[4]))
                 ],
-                typeof(string), _typeMappingSource.FindMapping(typeof(string)));
+                typeof(string[]), _typeMappingSource.FindMapping(typeof(string[])));
 
         // ── Parse Query ───────────────────────────────────────────
         if (method == ParseMethod) {


### PR DESCRIPTION
## Summary

Closes the coverage gaps from the previous PR. Adds 23 integration tests against a real ParadeDB container and 10 unit tests for the SQL-expression classes — covering every per-column attribute, every parameterless tokenizer (plus `Ngram` and `Regex`), a non-English stemmer language, the boosted/term-set/snop/fuzzy/snippets/regex/phrase-prefix/parse-flags branches of the search API, the `Range`/`Should`/`MustNot` factories on `ParadeDbJsonQuery`, and the composed-LINQ pattern from the README.

Two library bugs surfaced and got fixed in the same PR:
1. `pdb.snippets` returns `text[]`, not `text` — `Snippets` return type changed from `string` to `string[]`. Existing callers will see a one-line breaking signature change; before this PR the method threw at runtime when materialised.
2. The ngram tokenizer config requires `prefix_only` to be present even when false — the builder now always emits it.

Bumps version `0.2.1` -> `0.2.2`.

## Code changes

- `ParadeDbFunctions.cs`, `ParadeDbMethodCallTranslator.cs` — `Snippets` now returns `string[]`; translator maps the function expression's type/mapping to `typeof(string[])`.
- `Internal/Bm25StorageParameterBuilder.cs` — `prefix_only` always emitted in ngram tokenizer JSON. Matching unit-test assertion in `Bm25IndexConfigurationTests.cs` updated to the new expected SQL.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/IntegrationDbContext.cs` — adds `Product`, `KeywordRecord`, `NgramRecord`, `IcuRecord`, `SourceCodeRecord`, `RegexRecord`, `GermanArticle` entities. All use `[Table("snake_case")]` + `[Column("snake_case")]` so JSON `Term` filters and `MoreLikeThis` work (per the column-naming caveat from PR #5).
- `ParadeDbFixture.cs` — seed payloads for the new entities.
- `FieldTypeTests.cs` — 3 tests: Bm25Boolean filter, Bm25DateTime range filter, Bm25Json end-to-end.
- `TokenizerTests.cs` — 6 tests: Keyword preserves whole codes, Ngram matches substrings, Icu handles diacritics, SourceCode splits CamelCase, Regex tokenizes by pattern, German stemmer matches word variants.
- `SearchApiTests.cs` — 10 tests covering Boosted, TermSet, Phrase+slop, AllFuzzy, TermFuzzy, Snippets, Regex, PhrasePrefix, Parse-flags, and the composed README pattern.
- `JsonQueryTests.cs` — 4 tests: Range, Should (OR), MustNot (NOT), inline-builder overload.
- `ExpressionTests.cs` — 10 unit tests covering `Equals` / `GetHashCode` / `Print` / `Quote` (net9+) on `ParadeDbModifiedQueryExpression` and `ParadeDbNamedArgFunctionExpression`. Uses a minimal `StubSqlExpression` for the inner expressions so the test doesn't depend on `SqlConstantExpression` constructor shape (which differs across EF Core 8/9/10).
- `Directory.Build.props` — version `0.2.1` -> `0.2.2`.

## Test results

- Unit tests: 96 pass on net9 / net10, 94 on net8 (two `Quote()` tests gated by `#if NET9_0_OR_GREATER`).
- Integration tests: 37 pass on net10 against `paradedb/paradedb:latest`.