### PR TITLE
test(integration): add OrderByScoreDescending equivalence test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class OrderByScoreTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbSearchExtensions.OrderByScoreDescending composes a Score() ORDER BY
+    // equivalent to writing .OrderByDescending(a => EF.Functions.Score(a.Id)) by hand.
+    // A regression in the reflection-built expression (wrong Queryable overload, missing
+    // Convert for a value-type key, broken StripConvert) would either throw at translation
+    // or produce a different ordering than the explicit form.
+    [Fact]
+    public async Task OrderByScoreDescending_RanksMatchingArticles_SameOrderAsExplicitScoreSelector() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var viaExtension = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "models machine learning"))
+            .OrderByScoreDescending(a => a.Id)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        var viaExplicit = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "models machine learning"))
+            .OrderByDescending(a => EF.Functions.Score(a.Id))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.True(viaExtension.Count >= 2,
+            $"Need at least 2 matches for ordering to be observable; got {viaExtension.Count}.");
+        Assert.Equal(viaExplicit, viaExtension);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test verifying `ParadeDbSearchExtensions.OrderByScoreDescending` produces the same ordering as an explicit `.OrderByDescending(a => EF.Functions.Score(a.Id))`.
- Closes a real gap: the extension dynamically builds the Score expression via reflection (`MakeGenericMethod`, `BoxIfNeeded`, `StripConvert`) and was not covered against real ParadeDB.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreTests.cs` — new `[Fact]` running against the shared `ParadeDbFixture`. Runs the same `Matches(content, "models machine learning")` query through both the extension and the explicit Score selector, then asserts the resulting title lists are equal (with a guard requiring at least 2 matches so the ordering is observable).