### PR TITLE
test(integration): add MatchesAllBoosted score-amplification test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesAllBoostedTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesAllBoostedTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class MatchesAllBoostedTests(ParadeDbFixture fixture) {
+    // Verifies MatchesAllBoosted translates to: column &&& 'query'::pdb.boost(factor)
+    // with AND semantics — distinct from MatchesBoosted (||| / OR). A regression in
+    // the method-call translator that drops the boost cast, or swaps the operator,
+    // would either return matches with unboosted scores or change the result set.
+    [Fact]
+    public async Task MatchesAllBoosted_AndOperator_AmplifiesScoreVsUnboostedMatchesAll() {
+        await using var ctx = fixture.CreateDbContext();
+        const double boostFactor = 5.0;
+
+        var boosted = await ctx.Articles
+            .Where(a => EF.Functions.MatchesAllBoosted(a.Content, "neural networks", boostFactor))
+            .Select(a => new { a.Title, Score = EF.Functions.Score(a.Id) })
+            .ToListAsync();
+        var unboosted = await ctx.Articles
+            .Where(a => EF.Functions.MatchesAll(a.Content, "neural networks"))
+            .Select(a => new { a.Title, Score = EF.Functions.Score(a.Id) })
+            .ToListAsync();
+
+        // Same AND semantics → same matching rows; only the score should differ.
+        Assert.Equal(unboosted.Select(x => x.Title).OrderBy(t => t),
+            boosted.Select(x => x.Title).OrderBy(t => t));
+        Assert.Contains(boosted, x => x.Title == "Introduction to neural networks");
+        var boostedHit = boosted.Single(x => x.Title == "Introduction to neural networks");
+        var unboostedHit = unboosted.Single(x => x.Title == "Introduction to neural networks");
+        Assert.True(boostedHit.Score > unboostedHit.Score * 2.0,
+            $"Boost factor {boostFactor} should amplify score substantially; " +
+            $"boosted={boostedHit.Score}, unboosted={unboostedHit.Score}.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test verifying `ParadeDbFunctions.MatchesAllBoosted` translates to the AND-boost form (`column &&& 'query'::pdb.boost(factor)`) and actually amplifies BM25 scores.
- Closes a real gap: only the OR variant (`MatchesBoosted`) was covered; a regression that dropped the boost cast or swapped `&&&` for `|||` would slip past current tests.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesAllBoostedTests.cs` — new `[Fact]` that runs the same `"neural networks"` query through `MatchesAllBoosted(content, query, 5.0)` and the unboosted `MatchesAll(content, query)`. Asserts (a) identical result set (proves AND semantics preserved), (b) the boosted score is more than 2× the unboosted score for the same row (proves the boost cast survived translation).