### PR TITLE
test(integration): add ParadeDbJsonQuery.PhrasePrefix autocomplete test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhrasePrefixTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhrasePrefixTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonPhrasePrefixTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.PhrasePrefix builds {"phrase_prefix":{"field":"...","phrases":[...]}}
+    // — the last phrase element is treated as a prefix (useful for autocomplete). The CLR
+    // PhrasePrefix translates via pdb.phrase_prefix(ARRAY[...]); this JSON form goes through
+    // the @@@ jsonb path. A regression in the phrases array or field key would either fail
+    // to match or change the match set entirely.
+    [Fact]
+    public async Task PhrasePrefix_LastTermAsPrefix_MatchesContainingDocument() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.PhrasePrefix("content", "neural", "net");
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // "neural net*" prefix-matches "Neural networks" in Article 1's content;
+        // unrelated articles (cooking, quantum) must not match.
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(hits, t => t == "Cooking pasta perfectly");
+        Assert.DoesNotContain(hits, t => t == "Quantum computing fundamentals");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbJsonQuery.PhrasePrefix`, the JSON form of phrase-prefix matching that powers autocomplete/type-ahead scenarios.
- Closes a real gap: only the CLR `PhrasePrefix` (which translates via `pdb.phrase_prefix(ARRAY[...])`) was covered. The JSON form `{"phrase_prefix":{"field":"...","phrases":[...]}}` goes through a different SQL path (`@@@ jsonb`) and was untested.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhrasePrefixTests.cs` — new `[Fact]` building `PhrasePrefix("content", "neural", "net")` and asserting that "Introduction to neural networks" matches (last term "net" prefix-matches "networks") while unrelated articles (cooking, quantum) do not.