### PR TITLE
test(integration): add skipped repro for GH-15 — MatchesFuzzy 5-arg overload

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class MatchesFuzzyOptionsTests(ParadeDbFixture fixture) {
+    // Verifies the 5-arg MatchesFuzzy overload translates the transpositionCostOne flag
+    // into pdb.fuzzy(distance, prefix, transposition_cost_one) so an adjacent-character
+    // swap counts as 1 edit (default: 2). "nueral" vs "neural" has Levenshtein distance 2
+    // but transposition distance 1 — at distance=1, transpositionCostOne is the only thing
+    // that makes the match succeed. A regression that drops the extra args (or swaps them)
+    // would flip both assertions.
+    [Fact(Skip = "GH-15 — 5-arg MatchesFuzzy emits invalid SQL: type modifiers must be simple constants")]
+    public async Task MatchesFuzzy_WithTranspositionCostOne_MatchesAdjacentSwapAtDistance1() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var withTransposition = await ctx.Articles
+            .Where(a => EF.Functions.MatchesFuzzy(a.Content, "nueral", 1,
+                prefix: false, transpositionCostOne: true))
+            .Select(a => a.Title)
+            .ToListAsync();
+        var withoutTransposition = await ctx.Articles
+            .Where(a => EF.Functions.MatchesFuzzy(a.Content, "nueral", 1,
+                prefix: false, transpositionCostOne: false))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // With transposition cost = 1, "nueral" ↔ "neural" is a single edit → matches.
+        Assert.Contains(withTransposition, t => t == "Introduction to neural networks");
+        // Without transposition cost = 1, the same query exceeds distance=1 → no match.
+        Assert.DoesNotContain(withoutTransposition, t => t == "Introduction to neural networks");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for the 5-arg `MatchesFuzzy(column, query, distance, prefix, transpositionCostOne)` overload — committed as `[Skip]` while #15 is open.
- The test discovered a real bug: the overload emits SQL that Postgres rejects with `42601: type modifiers must be simple constants or identifiers`. The `prefix`/`transpositionCostOne` booleans appear to be parameterized in the `pdb.fuzzy(distance, prefix, transposition_cost_one)` cast modifier, but PostgreSQL requires type-modifier args to be literal constants (same handling that already works for `distance` in the 3-arg form).

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs` — new `[Fact(Skip = "GH-15 — ...")]` capturing the expected behavior: with distance=1, `transpositionCostOne: true` should match `"nueral"` against `"neural"` (adjacent-swap = 1 edit), and `transpositionCostOne: false` should not (true Levenshtein = 2). **Skipped — see GH-15.** Un-skip once the translator inlines the boolean modifiers as literal constants.