### PR TITLE
test(integration): add skipped repro for GH-17 — PhrasePrefix 3-arg overload

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class PhrasePrefixMaxExpansionsTests(ParadeDbFixture fixture) {
+    // Verifies the 3-arg PhrasePrefix overload (with maxExpansions) translates to
+    // pdb.phrase_prefix(ARRAY[...], max_expansions => N) and runs. The 2-arg form is
+    // already tested; this exercises the extra named arg, which — if parameterized by
+    // the translator — would fail PostgreSQL parsing (cf. GH-15 for the fuzzy overloads).
+    [Fact(Skip = "GH-17 — 3-arg PhrasePrefix emits nonexistent pdb.phrase_prefix(text[], max_expansions => int) signature")]
+    public async Task PhrasePrefix_WithMaxExpansions_MatchesContainingDocument() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var hits = await ctx.Articles
+            .Where(a => EF.Functions.PhrasePrefix(a.Content, 5, "neural", "net"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(hits, t => t == "Cooking pasta perfectly");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for the 3-arg `PhrasePrefix(column, maxExpansions, params terms)` overload — committed as `[Skip]` while #17 is open.
- The test discovered a real bug: the overload generates a SQL call to `pdb.phrase_prefix(text[], max_expansions => integer)` which doesn't exist in the installed pg_search. Npgsql rejects it with `42883: function ... does not exist`. The 2-arg form (no `maxExpansions`) translates correctly and is already covered.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs` — new `[Fact(Skip = "GH-17 — ...")]` running `PhrasePrefix(content, 5, "neural", "net")` and asserting that "Introduction to neural networks" matches and unrelated articles don't. **Skipped — see GH-17.** Un-skip once the translator emits the actual `pdb.phrase_prefix` signature exposed by pg_search.