### PR TITLE
test(integration): add MoreLikeThis 3-arg overload with fields test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MoreLikeThisFieldsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MoreLikeThisFieldsTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class MoreLikeThisFieldsTests(ParadeDbFixture fixture) {
+    // Verifies MoreLikeThis(keyField, documentId, params string[] fields) translates to
+    // pdb.more_like_this(documentId, ARRAY['field1', ...]) — restricting the similarity
+    // computation to the named fields. The 2-arg form is already covered; this exercises
+    // the array-of-strings parameter, distinct from GH-15/GH-17 translation paths.
+    [Fact]
+    public async Task MoreLikeThis_WithFieldsRestriction_ExecutesAndReturnsSimilarArticle() {
+        await using var ctx = fixture.CreateDbContext();
+        var seed = await ctx.Articles.SingleAsync(a => a.Title == "Introduction to neural networks");
+
+        var related = await ctx.Articles
+            .Where(a => EF.Functions.MoreLikeThis(a.Id, seed.Id, "content"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // pg_search similarity threshold is weak with so few seeded rows, so we don't
+        // assert exclusions — only that the function executes and the most-similar
+        // article (Transformers — shares "models", "running", etc.) is present.
+        Assert.Contains(related, t => t == "Transformer architectures");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbFunctions.MoreLikeThis(keyField, documentId, params string[] fields)` — the field-restricted form.
- Closes a real gap: only the 2-arg form was covered. The 3-arg form translates to `pdb.more_like_this(documentId, ARRAY['field1', ...])` with a distinct array-of-strings parameter path. Unlike the recently filed GH-15/GH-17 cases, this overload translates and runs correctly — the test confirms it and locks the behavior in.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MoreLikeThisFieldsTests.cs` — new `[Fact]` calling `MoreLikeThis(a.Id, seed.Id, "content")` against the existing "Introduction to neural networks" seed. Asserts the most similar article ("Transformer architectures") is in the result set. Doesn't over-assert exclusions because pg_search's similarity threshold is weak on the small seed corpus.