### PR TITLE
test(integration): add skipped repro for GH-23 — JSON MoreLikeThis wrong key

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonMoreLikeThisTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.MoreLikeThis builds {"more_like_this":{"document_id":N}}
+    // and pg_search accepts it via the @@@ jsonb path. Distinct from the CLR MoreLikeThis
+    // (which translates via pdb.more_like_this(documentId)) — a regression in the JSON
+    // key names would still return zero matches without surfacing the underlying mistake.
+    [Fact(Skip = "GH-23 — JSON MoreLikeThis emits {\"document_id\":N}; pg_search needs key_value or document")]
+    public async Task MoreLikeThis_FromSeedArticle_ExecutesAndReturnsSimilarArticle() {
+        await using var ctx = fixture.CreateDbContext();
+        var seed = await ctx.Articles.SingleAsync(a => a.Title == "Introduction to neural networks");
+
+        var query = ParadeDbJsonQuery.MoreLikeThis(seed.Id);
+
+        var related = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // pg_search's similarity threshold is weak on the seeded corpus, so we only
+        // assert the most-similar candidate is present (matches the existing CLR MLT test).
+        Assert.Contains(related, t => t == "Transformer architectures");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for `ParadeDbJsonQuery.MoreLikeThis` — committed as `[Skip]` while #23 is open.
- The test discovered a real bug: the factory emits `{"more_like_this":{"document_id":N}}`, but pg_search's `@@@ jsonb` parser rejects it with `XX000: more_like_this must be called with either key_value or document`. The CLR-side `MoreLikeThis` translation works correctly, so the bug is isolated to the JSON builder.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs` — new `[Fact(Skip = "GH-23 — ...")]` mirroring the existing CLR `MoreLikeThis_ExecutesAndReturnsRelatedArticle` test but going through the JSON @@@ path. **Skipped — see GH-23.** Un-skip once `ParadeDbJsonQuery.MoreLikeThis` emits the JSON shape pg_search accepts (`key_value` / `document`).