### PR TITLE
test(integration): add ParadeDbJsonQuery.Phrase slop-tolerance test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhraseSlopTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhraseSlopTests.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonPhraseSlopTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Phrase with slop produces {"phrase":{"field":"...","phrases":[...],"slop":N}}
+    // and pg_search allows N words between phrase terms. Article 1's content has "Deep learning models" —
+    // strict "deep models" doesn't match (1 word in between), but slop>=1 does.
+    // A regression that dropped the "slop" key would fail the test by returning zero matches.
+    [Fact]
+    public async Task Phrase_WithSlop_AllowsWordsBetweenTerms() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var strict = await ctx.Articles
+            .JsonSearch(a => a.Id, ParadeDbJsonQuery.Phrase("content", "deep", "models"))
+            .Select(a => a.Title)
+            .ToListAsync();
+        var withSlop = await ctx.Articles
+            .JsonSearch(a => a.Id, ParadeDbJsonQuery.Phrase("content", 2, "deep", "models"))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.DoesNotContain(strict, t => t == "Introduction to neural networks");
+        Assert.Contains(withSlop, t => t == "Introduction to neural networks");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbJsonQuery.Phrase` with the `slop` overload (`{"phrase":{"field":"...","phrases":[...],"slop":N}}`).
- Closes a real gap: the no-slop overload mirrors the already-tested CLR `MatchesPhrase`, but the slop variant has an extra `"slop":N` key that exercises a different proximity-matching path. A regression dropping that key would return zero matches.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonPhraseSlopTests.cs` — new `[Fact]` running both `Phrase("content", "deep", "models")` (strict) and `Phrase("content", 2, "deep", "models")` (slop=2). Asserts the strict form excludes Article 1 (because "Deep learning models" has one word between "deep" and "models") and the slop form includes it.