### PR TITLE
test(integration): add ParadeDbJsonQuery.Regex pattern-match test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRegexTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRegexTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonRegexTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Regex builds {"regex":{"field":"...","pattern":"..."}} and
+    // pg_search accepts it via the @@@ jsonb path. Distinct from the CLR Regex translation
+    // (which uses pdb.regex(...)). A regression in the "regex"/"field"/"pattern" key names
+    // would either fail to deserialize or return zero matches.
+    [Fact]
+    public async Task Regex_Pattern_MatchesIndexedTokensMatchingExpression() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Regex("content", "neur.*");
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(hits, t => t == "Cooking pasta perfectly");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbJsonQuery.Regex`, the JSON form of regex token matching (`{"regex":{"field":"...","pattern":"..."}}`).
- Closes a real gap: the CLR `EF.Functions.Regex(...)` is already covered, but the JSON path goes through `@@@ jsonb` and has its own three-key shape — a regression in any of `regex`/`field`/`pattern` would either fail to deserialize or return zero matches.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRegexTests.cs` — new `[Fact]` building `Regex("content", "neur.*")` against the existing seed corpus. Asserts "Introduction to neural networks" matches (its content has "neural" / "Neural") and the unrelated cooking article is excluded.