### PR TITLE
test(integration): add OrderByScore ascending equivalence test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreAscendingTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreAscendingTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class OrderByScoreAscendingTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbSearchExtensions.OrderByScore composes an ascending Score()
+    // ORDER BY equivalent to .OrderBy(a => EF.Functions.Score(a.Id)) by hand. Pairs
+    // with the already-covered OrderByScoreDescending — both branches of the shared
+    // reflection-built ApplyScoreOrdering helper need a regression guard.
+    [Fact]
+    public async Task OrderByScore_RanksMatchingArticles_SameOrderAsExplicitScoreSelector() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var viaExtension = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "models machine learning"))
+            .OrderByScore(a => a.Id)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        var viaExplicit = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "models machine learning"))
+            .OrderBy(a => EF.Functions.Score(a.Id))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.True(viaExtension.Count >= 2,
+            $"Need at least 2 matches for ordering to be observable; got {viaExtension.Count}.");
+        Assert.Equal(viaExplicit, viaExtension);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbSearchExtensions.OrderByScore` (ascending) — the descending sibling was covered earlier this loop.
- Closes a real gap: both extension methods funnel through the same `ApplyScoreOrdering` reflection helper, but they pass different `Queryable` method names (`OrderBy` vs `OrderByDescending`). Locking both branches guards against a regression that only breaks one.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/OrderByScoreAscendingTests.cs` — new `[Fact]` running the same `Matches(content, "models machine learning")` query through both `.OrderByScore(a => a.Id)` and an explicit `.OrderBy(a => EF.Functions.Score(a.Id))`. Asserts both produce the same title ordering, with a guard requiring at least 2 matches so ordering is observable.