### PR TITLE
test(integration): add ParadeDbJsonQuery.Exists field-presence test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonExistsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonExistsTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonExistsTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Exists produces {"exists":{"field":"..."}} and pg_search
+    // returns every row that has the named field indexed. The two-key shape is small, so
+    // the test serves mainly as a regression guard against typos in "exists"/"field".
+    [Fact]
+    public async Task Exists_OnPopulatedField_MatchesAllIndexedRows() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Exists("category");
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // All 4 seeded articles have a category value, so Exists matches the whole corpus.
+        Assert.Equal(4, hits.Count);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `ParadeDbJsonQuery.Exists`, the JSON form for "this document has the named field" (`{"exists":{"field":"..."}}`).
- Closes a real gap: the helper was untested. Small shape, but worth a regression guard against typos in `exists` / `field`.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonExistsTests.cs` — new `[Fact]` running `Exists("category")` against the seed corpus and asserting all 4 articles match (they all have a category value indexed).