### PR TITLE
test(integration): add Snippet no-arg overload default-tag test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SnippetDefaultTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SnippetDefaultTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class SnippetDefaultTests(ParadeDbFixture fixture) {
+    // Verifies the no-arg Snippet overload translates to bare pdb.snippet(column) — distinct
+    // from the parameterised pdb.snippet(column, start_tag => ..., end_tag => ..., max_num_chars => ...)
+    // form that's already tested. Default ParadeDB tags are <b>...</b>. A regression that
+    // routed through the named-arg path would either fail or change the highlight markers.
+    [Fact]
+    public async Task Snippet_NoArgs_HighlightsWithDefaultBoldTags() {
+        await using var ctx = fixture.CreateDbContext();
+
+        var snippets = await ctx.Articles
+            .Where(a => EF.Functions.Matches(a.Content, "neural networks"))
+            .Select(a => EF.Functions.Snippet(a.Content))
+            .ToListAsync();
+
+        Assert.NotEmpty(snippets);
+        Assert.Contains(snippets, s => s != null && s.Contains("<b>") && s.Contains("</b>"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test for `EF.Functions.Snippet(column)` — the convenience overload that emits bare `pdb.snippet(column)` and relies on ParadeDB's default `<b>...</b>` highlight tags.
- Closes the last small gap on `ParadeDbFunctions`: the parameterised 4-arg form is covered, but the no-arg form has a distinct SQL shape (no `start_tag => ...`, `end_tag => ...`, `max_num_chars => ...` named args). Worth a regression guard since prior loop iterations surfaced bugs in other 1-arg vs N-arg overloads (GH-15 fuzzy, GH-17 phrase_prefix).

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SnippetDefaultTests.cs` — new `[Fact]` calling `Snippet(a.Content)` (no tag args) on matches of "neural networks". Asserts at least one returned snippet contains the default `<b>` / `</b>` markers.