### PR TITLE
fix(json-query): emit key_value (not document_id) in MoreLikeThis JSON

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs
@@ -4,11 +4,11 @@ namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
 
 [Collection(nameof(ParadeDbCollection))]
 public class JsonMoreLikeThisTests(ParadeDbFixture fixture) {
-    // Verifies ParadeDbJsonQuery.MoreLikeThis builds {"more_like_this":{"document_id":N}}
+    // Verifies ParadeDbJsonQuery.MoreLikeThis builds {"more_like_this":{"key_value":N}}
     // and pg_search accepts it via the @@@ jsonb path. Distinct from the CLR MoreLikeThis
     // (which translates via pdb.more_like_this(documentId)) — a regression in the JSON
     // key names would still return zero matches without surfacing the underlying mistake.
-    [Fact(Skip = "GH-23 — JSON MoreLikeThis emits {\"document_id\":N}; pg_search needs key_value or document")]
+    [Fact]
     public async Task MoreLikeThis_FromSeedArticle_ExecutesAndReturnsSimilarArticle() {
         await using var ctx = fixture.CreateDbContext();
         var seed = await ctx.Articles.SingleAsync(a => a.Title == "Introduction to neural networks");

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
@@ -244,7 +244,7 @@ public class ParadeDbJsonQueryTests {
     public void MoreLikeThis_creates_correct_json() {
         var json = ParadeDbJsonQuery.MoreLikeThis(42).ToJson();
         var doc = Parse(json);
-        Assert.Equal(42, doc.GetProperty("more_like_this").GetProperty("document_id").GetInt32());
+        Assert.Equal(42, doc.GetProperty("more_like_this").GetProperty("key_value").GetInt32());
     }
 
     // ── Boolean ──────────────────────────────────────────────────────

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
@@ -209,10 +209,10 @@ public sealed class ParadeDbJsonQuery {
     // ── More Like This ───────────────────────────────────────────────
 
     /// <summary>
-    /// More-like-this query. Produces: <c>{"more_like_this":{"document_id":N}}</c>.
+    /// More-like-this query. Produces: <c>{"more_like_this":{"key_value":N}}</c>.
     /// </summary>
     public static ParadeDbJsonQuery MoreLikeThis(int documentId) =>
-        new(new JsonObject { ["more_like_this"] = new JsonObject { ["document_id"] = documentId } });
+        new(new JsonObject { ["more_like_this"] = new JsonObject { ["key_value"] = documentId } });
 
     // ── Boolean ──────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Available query types:
 | `Exists("field")` | `{"exists":{"field":"..."}}` |
 | `All()` | `{"all":null}` |
 | `DisjunctionMax(queries...)` | `{"disjunction_max":{"disjuncts":[...]}}` |
-| `MoreLikeThis(documentId)` | `{"more_like_this":{"document_id":N}}` |
+| `MoreLikeThis(documentId)` | `{"more_like_this":{"key_value":N}}` |
 | `Boolean(b => b.Must(...).Should(...).MustNot(...))` | Boolean combinations |
 
 ### Combining with LINQ


### PR DESCRIPTION
## Summary

- Fixes #23: `ParadeDbJsonQuery.MoreLikeThis(int)` was emitting `{"more_like_this":{"document_id":N}}`, which pg_search's `@@@ jsonb` parser rejects with `XX000: more_like_this must be called with either key_value or document`.
- The CLR-side `EF.Functions.MoreLikeThis(...)` was unaffected (it goes through `pdb.more_like_this(<id>)`, a positional SQL call). Only the JSON builder used the wrong key.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs` — emit `"key_value"` instead of `"document_id"`; doc comment updated.
- `Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs` — assertion updated to the new key.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMoreLikeThisTests.cs` — un-skipped the regression test that was committed when #23 was filed; comment updated.
- `README.md` — quick-reference JSON shape table updated.