### PR TITLE
fix(translator): emit pdb.phrase_prefix max_expansion (not max_expansions)

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs
@@ -5,10 +5,9 @@ namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
 [Collection(nameof(ParadeDbCollection))]
 public class PhrasePrefixMaxExpansionsTests(ParadeDbFixture fixture) {
     // Verifies the 3-arg PhrasePrefix overload (with maxExpansions) translates to
-    // pdb.phrase_prefix(ARRAY[...], max_expansions => N) and runs. The 2-arg form is
-    // already tested; this exercises the extra named arg, which — if parameterized by
-    // the translator — would fail PostgreSQL parsing (cf. GH-15 for the fuzzy overloads).
-    [Fact(Skip = "GH-17 — 3-arg PhrasePrefix emits nonexistent pdb.phrase_prefix(text[], max_expansions => int) signature")]
+    // pdb.phrase_prefix(ARRAY[...], max_expansion => N) and runs. Guards against drift
+    // back to the plural "max_expansions" — pg_search's named arg is singular.
+    [Fact]
     public async Task PhrasePrefix_WithMaxExpansions_MatchesContainingDocument() {
         await using var ctx = fixture.CreateDbContext();
 

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
@@ -212,7 +212,7 @@ public class QueryTranslationTests : IDisposable {
         var sql = Sql(_db.Articles.Where(a => EF.Functions.PhrasePrefix(a.Content, 10, "running", "sh")));
         Assert.Contains("@@@", sql);
         Assert.Contains("pdb.phrase_prefix(", sql);
-        Assert.Contains("max_expansions =>", sql);
+        Assert.Contains("max_expansion =>", sql);
     }
 
     // ── More Like This ────────────────────────────────────────────────

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
@@ -196,7 +196,7 @@ public static class ParadeDbFunctions {
         => throw new InvalidOperationException(OnlyInLinq);
 
     /// <summary>
-    /// Phrase prefix match with max expansions. Translates to: column @@@ pdb.phrase_prefix(ARRAY[...], max_expansions => N).
+    /// Phrase prefix match with max expansions. Translates to: column @@@ pdb.phrase_prefix(ARRAY[...], max_expansion => N).
     /// </summary>
     public static bool PhrasePrefix(this DbFunctions _, string column, int maxExpansions, params string[] terms)
         => throw new InvalidOperationException(OnlyInLinq);

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
@@ -244,7 +244,7 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
         if (method == PhrasePrefixMaxMethod) {
             var phrasePrefixFunc = new ParadeDbNamedArgFunctionExpression("pdb.phrase_prefix",
                 [Map(arguments[3])],
-                [("max_expansions", Map(arguments[2]))],
+                [("max_expansion", Map(arguments[2]))],
                 typeof(bool), _typeMappingSource.FindMapping(typeof(bool)));
             return MakeBinaryBool(arguments[1], "@@@", phrasePrefixFunc);
         }

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ var results = await dbContext.Articles
 
 ```sql
 SELECT * FROM "Articles" WHERE "Content" @@@ pdb.phrase_prefix(ARRAY['running', 'sh'])
-SELECT * FROM "Articles" WHERE "Content" @@@ pdb.phrase_prefix(ARRAY['running', 'sh'], max_expansions => 10)
+SELECT * FROM "Articles" WHERE "Content" @@@ pdb.phrase_prefix(ARRAY['running', 'sh'], max_expansion => 10)
 ```
 
 ### More Like This


### PR DESCRIPTION
## Summary

- Fixes #17: pg_search's `pdb.phrase_prefix` accepts `max_expansion` (singular) as its named arg; the translator was emitting `max_expansions` (plural), so PostgreSQL returned `42883: function pdb.phrase_prefix(text[], max_expansions => integer) does not exist`.
- Verified against the running container — `pg_get_function_arguments` reports `phrase_prefix(phrases text[], max_expansion integer DEFAULT NULL)`.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs` — emit `"max_expansion"` instead of `"max_expansions"`.
- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs` — doc comment updated.
- `Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs` — `Assert.Contains` updated to the singular form.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/PhrasePrefixMaxExpansionsTests.cs` — un-skipped the regression test that was committed when #17 was filed; comment updated.
- `README.md` — SQL example updated.

The public C# parameter name (`maxExpansions`) is unchanged — only the emitted SQL keyword.