### PR TITLE
fix(translator): route 5-arg fuzzy overloads through pdb.match / pdb.fuzzy_term

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs
@@ -10,7 +10,7 @@ public class MatchesFuzzyOptionsTests(ParadeDbFixture fixture) {
     // but transposition distance 1 — at distance=1, transpositionCostOne is the only thing
     // that makes the match succeed. A regression that drops the extra args (or swaps them)
     // would flip both assertions.
-    [Fact(Skip = "GH-15 — 5-arg MatchesFuzzy emits invalid SQL: type modifiers must be simple constants")]
+    [Fact]
     public async Task MatchesFuzzy_WithTranspositionCostOne_MatchesAdjacentSwapAtDistance1() {
         await using var ctx = fixture.CreateDbContext();
 

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
@@ -63,10 +63,14 @@ public class QueryTranslationTests : IDisposable {
     }
 
     [Fact]
-    public void MatchesFuzzy_full_generates_fuzzy_with_options() {
+    public void MatchesFuzzy_full_generates_pdb_match_with_options() {
         var sql = Sql(_db.Articles.Where(a => EF.Functions.MatchesFuzzy(a.Content, "machin", 2, true, false)));
-        Assert.Contains("|||", sql);
-        Assert.Contains("::pdb.fuzzy(2, true, false)", sql);
+        Assert.Contains("@@@", sql);
+        Assert.Contains("pdb.match(", sql);
+        Assert.Contains("distance =>", sql);
+        Assert.Contains("transposition_cost_one =>", sql);
+        Assert.Contains("prefix =>", sql);
+        Assert.DoesNotContain("conjunction_mode =>", sql);
     }
 
     [Fact]
@@ -77,10 +81,11 @@ public class QueryTranslationTests : IDisposable {
     }
 
     [Fact]
-    public void MatchesAllFuzzy_full_generates_and_with_fuzzy_options() {
+    public void MatchesAllFuzzy_full_generates_pdb_match_with_conjunction() {
         var sql = Sql(_db.Articles.Where(a => EF.Functions.MatchesAllFuzzy(a.Content, "machin", 1, false, true)));
-        Assert.Contains("&&&", sql);
-        Assert.Contains("::pdb.fuzzy(1, false, true)", sql);
+        Assert.Contains("@@@", sql);
+        Assert.Contains("pdb.match(", sql);
+        Assert.Contains("conjunction_mode =>", sql);
     }
 
     [Fact]
@@ -91,10 +96,10 @@ public class QueryTranslationTests : IDisposable {
     }
 
     [Fact]
-    public void MatchesTermFuzzy_full_generates_term_with_fuzzy_options() {
+    public void MatchesTermFuzzy_full_generates_pdb_fuzzy_term_function() {
         var sql = Sql(_db.Articles.Where(a => EF.Functions.MatchesTermFuzzy(a.Content, "machin", 2, true, true)));
-        Assert.Contains("===", sql);
-        Assert.Contains("::pdb.fuzzy(2, true, true)", sql);
+        Assert.Contains("@@@", sql);
+        Assert.Contains("pdb.fuzzy_term(", sql);
     }
 
     // ── Boost ─────────────────────────────────────────────────────────

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs
@@ -67,7 +67,7 @@ public static class ParadeDbFunctions {
         => throw new InvalidOperationException(OnlyInLinq);
 
     /// <summary>
-    /// Fuzzy OR match with options. Translates to: column ||| 'query'::pdb.fuzzy(distance, prefix, transpositionCostOne).
+    /// Fuzzy OR match with options. Translates to: column @@@ pdb.match('query', distance =&gt; D, transposition_cost_one =&gt; T, prefix =&gt; P).
     /// <paramref name="prefix"/> exempts the initial substring from edit distance.
     /// <paramref name="transpositionCostOne"/> counts swapping two adjacent characters as one edit.
     /// </summary>
@@ -82,7 +82,7 @@ public static class ParadeDbFunctions {
         => throw new InvalidOperationException(OnlyInLinq);
 
     /// <summary>
-    /// Fuzzy AND match with options. Translates to: column &&& 'query'::pdb.fuzzy(distance, prefix, transpositionCostOne).
+    /// Fuzzy AND match with options. Translates to: column @@@ pdb.match('query', distance =&gt; D, transposition_cost_one =&gt; T, prefix =&gt; P, conjunction_mode =&gt; true).
     /// </summary>
     public static bool MatchesAllFuzzy(this DbFunctions _, string column, string query, int distance,
         bool prefix, bool transpositionCostOne)
@@ -95,7 +95,7 @@ public static class ParadeDbFunctions {
         => throw new InvalidOperationException(OnlyInLinq);
 
     /// <summary>
-    /// Fuzzy term match with options. Translates to: column === 'query'::pdb.fuzzy(distance, prefix, transpositionCostOne).
+    /// Fuzzy term match with options. Translates to: column @@@ pdb.fuzzy_term('query', distance, transposition_cost_one, prefix).
     /// </summary>
     public static bool MatchesTermFuzzy(this DbFunctions _, string column, string query, int distance,
         bool prefix, bool transpositionCostOne)

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs
@@ -144,19 +144,22 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
             return MakeBinaryBool(arguments[1], "|||", WithModifier(arguments[2], BuildFuzzySuffix(arguments[3])));
 
         if (method == MatchesFuzzyFullMethod)
-            return MakeBinaryBool(arguments[1], "|||", WithModifier(arguments[2], BuildFuzzyFullSuffix(arguments[3], arguments[4], arguments[5])));
+            return MakeBinaryBool(arguments[1], "@@@",
+                BuildFuzzyMatchFunc(arguments[2], arguments[3], arguments[4], arguments[5], conjunctionMode: false));
 
         if (method == MatchesAllFuzzyMethod)
             return MakeBinaryBool(arguments[1], "&&&", WithModifier(arguments[2], BuildFuzzySuffix(arguments[3])));
 
         if (method == MatchesAllFuzzyFullMethod)
-            return MakeBinaryBool(arguments[1], "&&&", WithModifier(arguments[2], BuildFuzzyFullSuffix(arguments[3], arguments[4], arguments[5])));
+            return MakeBinaryBool(arguments[1], "@@@",
+                BuildFuzzyMatchFunc(arguments[2], arguments[3], arguments[4], arguments[5], conjunctionMode: true));
 
         if (method == MatchesTermFuzzyMethod)
             return MakeBinaryBool(arguments[1], "===", WithModifier(arguments[2], BuildFuzzySuffix(arguments[3])));
 
         if (method == MatchesTermFuzzyFullMethod)
-            return MakeBinaryBool(arguments[1], "===", WithModifier(arguments[2], BuildFuzzyFullSuffix(arguments[3], arguments[4], arguments[5])));
+            return MakeBinaryBool(arguments[1], "@@@",
+                BuildFuzzyTermFunc(arguments[2], arguments[3], arguments[4], arguments[5]));
 
         // ── Boost ─────────────────────────────────────────────────
         if (method == MatchesBoostedMethod)
@@ -297,21 +300,33 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
             ? value
             : throw new InvalidOperationException("ParadeDB modifier parameters (boost factor) must be compile-time constants.");
 
-    private static bool ExtractBool(SqlExpression expr) =>
-        expr is SqlConstantExpression { Value: bool value }
-            ? value
-            : throw new InvalidOperationException("ParadeDB modifier parameters (prefix, transpositionCostOne) must be compile-time constants.");
-
     private static string BuildFuzzySuffix(SqlExpression distanceExpr) {
         var distance = ExtractInt(distanceExpr);
         return $"::pdb.fuzzy({distance})";
     }
 
-    private static string BuildFuzzyFullSuffix(SqlExpression distanceExpr, SqlExpression prefixExpr, SqlExpression transpExpr) {
-        var distance = ExtractInt(distanceExpr);
-        var prefix = ExtractBool(prefixExpr);
-        var transp = ExtractBool(transpExpr);
-        return $"::pdb.fuzzy({distance}, {BoolLit(prefix)}, {BoolLit(transp)})";
+    // pdb.fuzzy(...) typmod accepts only a single int; the 5-arg fuzzy overloads route
+    // through pdb.match / pdb.fuzzy_term function calls instead. See README and GH-15.
+    private SqlExpression BuildFuzzyMatchFunc(SqlExpression queryExpr, SqlExpression distanceExpr,
+        SqlExpression prefixExpr, SqlExpression transpExpr, bool conjunctionMode) {
+        var named = new List<(string, SqlExpression)> {
+            ("distance", Map(distanceExpr)),
+            ("transposition_cost_one", Map(transpExpr)),
+            ("prefix", Map(prefixExpr)),
+        };
+        if (conjunctionMode) named.Add(("conjunction_mode", _sql.Constant(true, _typeMappingSource.FindMapping(typeof(bool)))));
+        return new ParadeDbNamedArgFunctionExpression("pdb.match",
+            [Map(queryExpr)], named,
+            typeof(bool), _typeMappingSource.FindMapping(typeof(bool)));
+    }
+
+    private SqlExpression BuildFuzzyTermFunc(SqlExpression queryExpr, SqlExpression distanceExpr,
+        SqlExpression prefixExpr, SqlExpression transpExpr) {
+        // pdb.fuzzy_term(value, distance, transposition_cost_one, prefix) — positional order.
+        return _sql.Function("pdb.fuzzy_term",
+            [Map(queryExpr), Map(distanceExpr), Map(transpExpr), Map(prefixExpr)],
+            nullable: true, argumentsPropagateNullability: [true, true, true, true],
+            typeof(bool), _typeMappingSource.FindMapping(typeof(bool)));
     }
 
     private static string BuildBoostSuffix(SqlExpression boostExpr) {
@@ -324,5 +339,4 @@ public sealed class ParadeDbMethodCallTranslator : IMethodCallTranslator {
         return $"::pdb.slop({slop})";
     }
 
-    private static string BoolLit(bool value) => value ? "true" : "false";
 }


### PR DESCRIPTION
## Summary

- Fixes #15. The 5-arg `MatchesFuzzy` / `MatchesAllFuzzy` / `MatchesTermFuzzy` overloads were emitting `'value'::pdb.fuzzy(distance, prefix, transposition_cost_one)` casts, which PostgreSQL rejects with `42601: type modifiers must be simple constants or identifiers`. PostgreSQL only accepts integer constants in type-modifier positions — booleans aren't allowed there at all, regardless of how the translator inlines them.
- Verified by querying `pg_proc` and running candidate SQL against the live ParadeDB container before settling on the function-call form.

## Approach

The 3-arg overloads (single integer typmod) keep the existing `'value'::pdb.fuzzy(N)` cast — that one is valid. The 5-arg overloads switch to function-call form, which accepts ordinary parameter binds for every arg type:

| Public API | New SQL |
|---|---|
| `MatchesFuzzy(col, q, d, prefix, transp)` | `col @@@ pdb.match(q, distance => d, transposition_cost_one => t, prefix => p)` |
| `MatchesAllFuzzy(col, q, d, prefix, transp)` | `col @@@ pdb.match(q, ..., conjunction_mode => true)` |
| `MatchesTermFuzzy(col, q, d, prefix, transp)` | `col @@@ pdb.fuzzy_term(q, d, t, p)` |

Verified against pg_search: `pdb.match(value, …, conjunction_mode)` and `pdb.fuzzy_term(value, distance, transposition_cost_one, prefix)` are the functions that actually expose these options.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbMethodCallTranslator.cs` — three 5-arg branches re-routed through new `BuildFuzzyMatchFunc` / `BuildFuzzyTermFunc` helpers; old `BuildFuzzyFullSuffix`, `ExtractBool`, and `BoolLit` removed (dead).
- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbFunctions.cs` — XML doc comments for the three overloads updated to describe the new translation.
- `Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs` — three unit tests updated to assert on the new `pdb.match(...)` / `pdb.fuzzy_term(...)` shape.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesFuzzyOptionsTests.cs` — un-skipped the regression test that was committed when #15 was filed.

All test suites pass: 96 unit tests on net8 / net9 / net10, 58 integration tests (zero skips for the first time since this loop started).