### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Patch bump for the v2.0.1 release. Tag will be pushed once this merges.

## Code changes

- `Directory.Build.props` — `<Version>` 2.0.0 → 2.0.1.

## What's in this release

Three translator bug fixes, found and captured by integration tests added earlier on master:

- #31 — `ParadeDbJsonQuery.MoreLikeThis` now emits `{"more_like_this":{"key_value":N}}` (was `document_id`, which pg_search rejected with XX000). Fixes #23.
- #32 — `PhrasePrefix(col, maxExpansions, terms)` now emits `max_expansion =>` (singular), matching the actual pg_search signature. Fixes #17.
- #33 — 5-arg `MatchesFuzzy` / `MatchesAllFuzzy` / `MatchesTermFuzzy` now route through `pdb.match(...)` / `pdb.fuzzy_term(...)` function calls; the old `'value'::pdb.fuzzy(d, prefix, transp)` cast was rejected by PostgreSQL (type modifiers only accept integer constants). Fixes #15.

Plus 21 new integration tests against a real ParadeDB container covering the previously untested public surface of `ParadeDbFunctions`, `ParadeDbJsonQuery`, and `ParadeDbSearchExtensions`.

No breaking changes — every behavior alteration is on a path that previously threw at execution time.