### PR TITLE
test(index-config): cover RegexPattern paired with non-Regex tokenizer

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
@@ -132,6 +132,12 @@ public class Bm25IndexConfigurationTests {
     }
 
     [Fact]
+    public void RegexParamWithoutRegexTokenizer_Throws() {
+        var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<RegexParamOnNonRegexTokenizerEntity>());
+        Assert.Contains("RegexPattern requires Tokenizer = Bm25Tokenizer.Regex", ex.Message);
+    }
+
+    [Fact]
     public void OrphanFieldAttributeWithoutBm25Index_Throws() {
         var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<OrphanNoIndexEntity>());
         Assert.Contains("OrphanText", ex.Message);
@@ -289,6 +295,13 @@ internal class NgramMissingMinMaxEntity {
 internal class RegexMissingPatternEntity {
     public int Id { get; set; }
     [Bm25Text(Tokenizer = Bm25Tokenizer.Regex)]
+    public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Content))]
+internal class RegexParamOnNonRegexTokenizerEntity {
+    public int Id { get; set; }
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Default, RegexPattern = "neuro.*")]
     public string Content { get; set; } = null!;
 }
 


### PR DESCRIPTION
## Summary
- Adds `RegexParamWithoutRegexTokenizer_Throws` and the `RegexParamOnNonRegexTokenizerEntity` fixture.
- The validator already rejected the inverse direction; this nails down the second arm so a regression can't ship a silently-ignored `RegexPattern`.

## Test plan
- [x] `dotnet test --filter Bm25IndexConfigurationTests` — 22 cases pass on net10.