### PR TITLE
test: cover remaining partial branches to push coverage past 99%

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/Bm25IndexConfigurationTests.cs
@@ -138,6 +138,27 @@ public class Bm25IndexConfigurationTests {
     }
 
     [Fact]
+    public void Bm25Numeric_WithIndexedFalse_EmitsIndexedFalse() {
+        var sql = GetCreateScript<NotIndexedNumericEntity>();
+        Assert.Contains("numeric_fields=", sql);
+        Assert.Contains("\"indexed\":false", sql);
+    }
+
+    [Fact]
+    public void Bm25Boolean_WithIndexedFalse_EmitsIndexedFalse() {
+        var sql = GetCreateScript<NotIndexedBooleanEntity>();
+        Assert.Contains("boolean_fields=", sql);
+        Assert.Contains("\"indexed\":false", sql);
+    }
+
+    [Fact]
+    public void Bm25DateTime_WithIndexedFalse_EmitsIndexedFalse() {
+        var sql = GetCreateScript<NotIndexedDateTimeEntity>();
+        Assert.Contains("datetime_fields=", sql);
+        Assert.Contains("\"indexed\":false", sql);
+    }
+
+    [Fact]
     public void OrphanFieldAttributeWithoutBm25Index_Throws() {
         var ex = Assert.Throws<InvalidOperationException>(() => GetCreateScript<OrphanNoIndexEntity>());
         Assert.Contains("OrphanText", ex.Message);
@@ -303,6 +324,27 @@ internal class RegexParamOnNonRegexTokenizerEntity {
     public int Id { get; set; }
     [Bm25Text(Tokenizer = Bm25Tokenizer.Default, RegexPattern = "neuro.*")]
     public string Content { get; set; } = null!;
+}
+
+[Bm25Index(nameof(Id), nameof(Rating))]
+internal class NotIndexedNumericEntity {
+    public int Id { get; set; }
+    [Bm25Numeric(Indexed = false)]
+    public int Rating { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(InStock))]
+internal class NotIndexedBooleanEntity {
+    public int Id { get; set; }
+    [Bm25Boolean(Indexed = false)]
+    public bool InStock { get; set; }
+}
+
+[Bm25Index(nameof(Id), nameof(PublishedAt))]
+internal class NotIndexedDateTimeEntity {
+    public int Id { get; set; }
+    [Bm25DateTime(Indexed = false)]
+    public DateTime PublishedAt { get; set; }
 }
 
 internal class OrphanNoIndexEntity {

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
@@ -216,4 +216,116 @@ public class ExpressionTests {
         Assert.Contains("hello", output);
         Assert.Contains("::pdb.fuzzy(2)", output);
     }
+
+    [Fact]
+    public void ModifiedQueryExpression_VisitChildren_returns_new_when_inner_changes() {
+        var original = Stub("hello");
+        var replacement = Stub("world");
+        var expr = new ParadeDbModifiedQueryExpression(original, "::pdb.boost(2)", typeof(string), original.TypeMapping);
+
+        var visitor = new ReplaceVisitor(original, replacement);
+        var result = visitor.Visit(expr);
+
+        var rebuilt = Assert.IsType<ParadeDbModifiedQueryExpression>(result);
+        Assert.NotSame(expr, rebuilt);
+        Assert.Same(replacement, rebuilt.InnerExpression);
+        Assert.Equal("::pdb.boost(2)", rebuilt.ModifierSuffix);
+    }
+
+    [Fact]
+    public void ModifiedQueryExpression_VisitChildren_returns_same_when_inner_unchanged() {
+        var inner = Stub("hello");
+        var expr = new ParadeDbModifiedQueryExpression(inner, "::pdb.boost(2)", typeof(string), inner.TypeMapping);
+
+        var visitor = new ReplaceVisitor(Stub("nothing-matches-this"), Stub("unused"));
+        var result = visitor.Visit(expr);
+
+        Assert.Same(expr, result);
+    }
+
+    // ── NamedArgFunctionExpression.Equals — remaining branch arms ──────
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForUnrelatedType() {
+        var arg = Stub("c");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg], [], typeof(string), arg.TypeMapping);
+
+        Assert.False(a.Equals("not an expression"));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentPositionalCount() {
+        var arg1 = Stub("c");
+        var arg2 = Stub("d");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg1], [], typeof(string), arg1.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg1, arg2], [], typeof(string), arg1.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentNamedCount() {
+        var arg = Stub("c");
+        var v = Stub("<b>");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", v)], typeof(string), arg.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", v), ("end_tag", v)], typeof(string), arg.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentPositionalValue() {
+        var arg1 = Stub("c");
+        var arg2 = Stub("d");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg1], [], typeof(string), arg1.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet", [arg2], [], typeof(string), arg1.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Equals_ReturnsFalseForDifferentNamedValue() {
+        var arg = Stub("c");
+        var v1 = Stub("<b>");
+        var v2 = Stub("<i>");
+        var a = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", v1)], typeof(string), arg.TypeMapping);
+        var b = new ParadeDbNamedArgFunctionExpression("pdb.snippet",
+            [arg], [("start_tag", v2)], typeof(string), arg.TypeMapping);
+
+        Assert.False(a.Equals(b));
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Print_emits_separator_between_multiple_positional_args() {
+        var p1 = Stub("c");
+        var p2 = Stub("d");
+        var expr = new ParadeDbNamedArgFunctionExpression("pdb.fn",
+            [p1, p2], [], typeof(string), p1.TypeMapping);
+
+        var printer = new ExpressionPrinter();
+        printer.Visit(expr);
+        var output = printer.ToString();
+
+        Assert.Contains("pdb.fn(", output);
+        Assert.Contains(", ", output);
+    }
+
+    [Fact]
+    public void NamedArgFunctionExpression_Print_handles_named_args_without_positional() {
+        var v1 = Stub("<b>");
+        var v2 = Stub("</b>");
+        var expr = new ParadeDbNamedArgFunctionExpression("pdb.fn",
+            [], [("start_tag", v1), ("end_tag", v2)], typeof(string), v1.TypeMapping);
+
+        var printer = new ExpressionPrinter();
+        printer.Visit(expr);
+        var output = printer.ToString();
+
+        Assert.Contains("pdb.fn(", output);
+        Assert.Contains("start_tag => ", output);
+        Assert.Contains("end_tag => ", output);
+    }
 }

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/InternalsCoverageTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/InternalsCoverageTests.cs
@@ -139,5 +139,24 @@ public class InternalsCoverageTests {
         var rebuilt = Assert.IsType<ParadeDbNamedArgFunctionExpression>(result);
         Assert.NotSame(expr, rebuilt);
     }
+
+    /// <summary>
+    /// Mirror of the named-arg rebuild test for <see cref="ParadeDbModifiedQueryExpression"/>:
+    /// when the wrapped inner gets folded by the processor, the wrapper has to be rebuilt
+    /// around the new instance — otherwise downstream visitors keep seeing the stale child.
+    /// </summary>
+    [Fact]
+    public void NullabilityProcessor_ModifiedQueryExpression_rebuilds_when_inner_simplified() {
+        var processor = CreateProcessor();
+        var sql = Services().GetService<ISqlExpressionFactory>()!;
+        var inner = sql.IsNotNull(sql.Constant("hi"));
+        var expr = new ParadeDbModifiedQueryExpression(inner, "::pdb.boost(2)", inner.Type, inner.TypeMapping);
+
+        var result = InvokeVisitCustom(processor, expr);
+
+        var rebuilt = Assert.IsType<ParadeDbModifiedQueryExpression>(result);
+        Assert.NotSame(expr, rebuilt);
+        Assert.Equal("::pdb.boost(2)", rebuilt.ModifierSuffix);
+    }
 }
 

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
@@ -175,6 +175,22 @@ public class ParadeDbJsonQueryTests {
     }
 
     [Fact]
+    public void Range_with_lower_exclusive_uses_excluded_key() {
+        var json = ParadeDbJsonQuery.Range("Price", 10, 100, lowerInclusive: false, upperInclusive: true).ToJson();
+        var range = Parse(json).GetProperty("range");
+        Assert.Equal(10, range.GetProperty("lower_bound").GetProperty("excluded").GetInt32());
+        Assert.Equal(100, range.GetProperty("upper_bound").GetProperty("included").GetInt32());
+    }
+
+    [Fact]
+    public void Range_with_upper_bound_only_creates_correct_json() {
+        var json = ParadeDbJsonQuery.Range("Price", null, 100).ToJson();
+        var range = Parse(json).GetProperty("range");
+        Assert.False(range.TryGetProperty("lower_bound", out _));
+        Assert.True(range.TryGetProperty("upper_bound", out _));
+    }
+
+    [Fact]
     public void Range_with_is_datetime_creates_correct_json() {
         var dt = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
         var json = ParadeDbJsonQuery.Range("ReportingDate", dt, null, isDatetime: true).ToJson();

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/QueryTranslationTests.cs
@@ -403,4 +403,41 @@ public class QueryTranslationTests : IDisposable {
         Assert.Contains("\"limit\" =>", sql);
         Assert.Contains("\"offset\" =>", sql);
     }
+
+    // ── Compile-time-constant guard ────────────────────────────────────
+
+    /// <summary>
+    /// Modifier params (distance, slop, boost) must be compile-time constants; the translator
+    /// rejects captured parameters because it needs the literal value to bake into the SQL
+    /// suffix (e.g. <c>::pdb.fuzzy(2)</c>). Captured int → SqlParameterExpression → throws.
+    /// </summary>
+    [Fact]
+    public void MatchesFuzzy_with_captured_distance_throws_at_translation() {
+        var distance = 2;
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Sql(_db.Articles.Where(a => EF.Functions.MatchesFuzzy(a.Content, "x", distance))));
+        Assert.Contains("compile-time constants", ex.Message);
+    }
+
+    [Fact]
+    public void MatchesBoosted_with_captured_boost_throws_at_translation() {
+        var boost = 2.0;
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Sql(_db.Articles.Where(a => EF.Functions.MatchesBoosted(a.Content, "x", boost))));
+        Assert.Contains("compile-time constants", ex.Message);
+    }
+
+    // ── JsonSearch with a reference-type key ───────────────────────────
+
+    /// <summary>
+    /// When the key selector resolves to a reference-typed property the lambda body is a
+    /// plain MemberAccess — not a Convert — so <c>StripConvert</c> and <c>BoxIfNeeded</c>
+    /// take their pass-through branches. The int-keyed tests don't exercise either path.
+    /// </summary>
+    [Fact]
+    public void JsonSearch_with_reference_type_key_emits_at_operator() {
+        var sql = Sql(_db.Chunks.JsonSearch(c => c.Content, ParadeDbJsonQuery.Parse("revenue")));
+        Assert.Contains("@@@", sql);
+        Assert.Contains("::jsonb", sql);
+    }
 }


### PR DESCRIPTION
## Why
Codecov was at **97.45%** on master because 19 lines were classified as **partial** — line was hit but at least one branch direction wasn't. The Codecov view explained where they were; this PR adds tests that cover the *accessible* ones.

Locally measured: **97.45% → 99.54%** (Codecov-style: hits / (hits + misses + partials)).

## What it covers

| Source file | Branches fixed |
|---|---|
| `Bm25StorageParameterBuilder` | `Indexed=false` on Numeric / Boolean / DateTime (3) |
| `ParadeDbJsonQuery` | `Range` with `lowerInclusive=false` and upper-only-bound (2) |
| `ParadeDbNamedArgFunctionExpression` | `Equals` arms (unrelated type, different positional / named count, different values), multi-positional `Print`, named-only `Print` (7) |
| `ParadeDbModifiedQueryExpression` | `VisitChildren` rebuild + pass-through paths (1) |
| `ParadeDbMethodCallTranslator` | `ExtractInt` / `ExtractDouble` throw on captured (non-constant) modifier params (2) |
| `ParadeDbSearchExtensions` | `StripConvert` / `BoxIfNeeded` reference-type pass-through (`JsonSearch` with `string` key) (2) |
| `ParadeDbSqlNullabilityProcessor` | `ParadeDbModifiedQueryExpression` rebuild branch (mirrors existing named-arg rebuild test) (1) |

## What's still left at ~0.5% — defensive only
- `ParadeDbModelFinalizingConvention.cs:28, 81, 84` — null-coalesce against EF Core metadata that upstream validation prevents from ever being null in practice.
- `ParadeDbQuerySqlGenerator.cs:27` — the `i > 0` separator for multi-positional named-arg expressions. No public API constructs multi-positional ones; every `ParadeDbNamedArgFunctionExpression` the translator builds has exactly one positional arg.

## Test plan
- [x] `dotnet test` on net8.0, net9.0, net10.0, + integration tests on net10 — **213/213, 213/213, 211/211, 58/58 pass**
- [x] Local Codecov-style merge: 858 hits / 0 misses / 4 partials / 862 total → **99.54%**