### PR TITLE
test(integration): add ParadeDbJsonQuery.Parse lenient/conjunction_mode regression

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseOptionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseOptionsTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonParseOptionsTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Parse(string, bool, bool) emits the JSON keys
+    // "lenient" and "conjunction_mode" — distinct from the 1-arg overload that
+    // emits only "query_string". The CLR sibling EF.Functions.Parse(...) is
+    // tested separately; the JSON path is what feeds @@@ 'jsonb' and a
+    // regression renaming either key (e.g. "lenient" → "strict") would silently
+    // flip the AND/OR meaning of every unquoted multi-term parse query.
+    [Fact]
+    public async Task Parse_WithConjunctionMode_RequiresAllTermsInsteadOfAny() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // "neural" appears only in Article 1; "quantum" only in Article 3 — no article has both.
+        var orQuery = ParadeDbJsonQuery.Parse("neural quantum", lenient: true, conjunctionMode: false);
+        var andQuery = ParadeDbJsonQuery.Parse("neural quantum", lenient: true, conjunctionMode: true);
+
+        var orHits = await ctx.Articles
+            .JsonSearch(a => a.Id, orQuery)
+            .Select(a => a.Title)
+            .ToListAsync();
+        var andHits = await ctx.Articles
+            .JsonSearch(a => a.Id, andQuery)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // OR semantics (conjunction_mode omitted): both articles match.
+        Assert.Contains(orHits, t => t == "Introduction to neural networks");
+        Assert.Contains(orHits, t => t == "Quantum computing fundamentals");
+        // AND semantics (conjunction_mode true): neither article has both terms.
+        Assert.DoesNotContain(andHits, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(andHits, t => t == "Quantum computing fundamentals");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test for the 3-arg `ParadeDbJsonQuery.Parse(string, bool, bool)` overload, which conditionally emits the JSON keys `"lenient"` and `"conjunction_mode"` and was previously not exercised through the `@@@ jsonb` path (only the CLR `EF.Functions.Parse` sibling was tested).
- A regression renaming `"conjunction_mode"` (or always-emitting it) would silently flip the OR/AND meaning of every unquoted multi-term parse query — nothing currently catches that.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseOptionsTests.cs` — new test contrasting `conjunctionMode: false` vs `true` on `"neural quantum"` against the seeded corpus where `"neural"` appears only in Article 1 and `"quantum"` only in Article 3. OR returns both; AND returns neither.