### PR TITLE
test(integration): add skipped repro for GH-47 — JSON FuzzyTerm transpositionCostOne

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonFuzzyTermOptionsTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.FuzzyTerm(field, value, distance, prefix,
+    // transpositionCostOne) conditionally emits the JSON keys "prefix" and
+    // "transposition_cost_one" on the {"fuzzy_term":{...}} node. Distinct from
+    // the CLR MatchesTermFuzzy 5-arg path (pdb.fuzzy_term positional function).
+    // A regression renaming "transposition_cost_one" (or hard-coding it) would
+    // silently make distance=1 reject the adjacent-swap that the test relies on.
+    [Fact(Skip = "GH-47 — JSON FuzzyTerm transpositionCostOne=false is indistinguishable from true")]
+    public async Task FuzzyTerm_WithTranspositionCostOne_MatchesAdjacentSwapAtDistance1() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // "nueral" ↔ "neural" is an adjacent transposition (transp distance 1, Levenshtein 2).
+        var withTransposition = ParadeDbJsonQuery.FuzzyTerm("content", "nueral", 1,
+            prefix: false, transpositionCostOne: true);
+        var withoutTransposition = ParadeDbJsonQuery.FuzzyTerm("content", "nueral", 1,
+            prefix: false, transpositionCostOne: false);
+
+        var hitsWith = await ctx.Articles
+            .JsonSearch(a => a.Id, withTransposition)
+            .Select(a => a.Title)
+            .ToListAsync();
+        var hitsWithout = await ctx.Articles
+            .JsonSearch(a => a.Id, withoutTransposition)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hitsWith, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(hitsWithout, t => t == "Introduction to neural networks");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for `ParadeDbJsonQuery.FuzzyTerm`'s 5-arg overload that uncovered a real bug — skipped — see GH-47.
- At `distance: 1`, the JSON `@@@` path matches `"nueral"` ↔ `"neural"` regardless of `transpositionCostOne`, while the symmetric CLR path (`MatchesTermFuzzy` 5-arg, covered by `MatchesTermFuzzyOptionsTests`) correctly rejects the `false` case. The JSON builder emits the option key conditionally, so `false` is indistinguishable from `true`.
- Test ships `[Fact(Skip = ...)]` so the artifact lives in the repo and can be un-skipped as part of the fix.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs` — new skipped test (`[Fact(Skip = "GH-47 — ...")]`) asserting that toggling `transpositionCostOne` should change the hit set on the JSON `fuzzy_term` path.