### PR TITLE
test(integration): add skipped repro for GH-51 — Range null bound panic

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonRangeOpenEndedTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Range omits the "upper_bound" key entirely
+    // when upperBound is null — the `if (upperBound != null)` branch. The
+    // existing JsonQueryTests/JsonDateTimeRangeTests always pass both bounds,
+    // so a regression that always emits "upper_bound" (or crashes on null)
+    // would only be caught here.
+    [Fact(Skip = "GH-51 — passing null bound emits JSON pg_search rejects (missing field upper_bound panic)")]
+    public async Task Range_WithNullUpperBound_MatchesAllValuesAtOrAboveLowerBound() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // Ratings in the seed: Article 1=5, 2=4, 3=3, 4=5. lower=4 inclusive,
+        // no upper → expect Articles 1, 2, 4 (rating >= 4); Article 3 excluded.
+        var query = ParadeDbJsonQuery.Range("rating",
+            lowerBound: 4, upperBound: null!, lowerInclusive: true);
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.Contains(hits, t => t == "Transformer architectures");
+        Assert.Contains(hits, t => t == "Cooking pasta perfectly");
+        Assert.DoesNotContain(hits, t => t == "Quantum computing fundamentals");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for `ParadeDbJsonQuery.Range`'s open-ended-bound behavior that uncovered a real bug — skipped — see GH-51.
- The doc-comment promises "Pass null for either bound to omit it", but the resulting JSON is rejected by pg_search with a Rust unwrap panic (`Error("missing field upper_bound", ...)`); the SQL itself errors out before any C# assertion runs.
- Test ships `[Fact(Skip = ...)]` so the artifact lives in the repo and can be un-skipped as part of the fix.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs` — new skipped test (`[Fact(Skip = "GH-51 — ...")]`) asserting that `Range("rating", lowerBound: 4, upperBound: null, lowerInclusive: true)` returns the seeded rating-≥-4 articles.