### PR TITLE
test(integration): add JSON Parse lenient-flag differentiation test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseLenientTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseLenientTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonParseLenientTests(ParadeDbFixture fixture) {
+    // Verifies ParadeDbJsonQuery.Parse's "lenient" JSON-key emission actually
+    // takes effect — the existing JsonParseOptionsTests pins lenient: true in
+    // both halves to isolate conjunction_mode, so the lenient branch is never
+    // contrasted end-to-end. Uses a malformed query string ("neural AND")
+    // that pg_search rejects in strict mode and tolerates in lenient mode —
+    // a regression dropping the "lenient" key would let the strict case parse.
+    [Fact]
+    public async Task Parse_WithLenientFalse_RejectsMalformedQueryThatLenientTrueAccepts() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // Trailing AND with no right-hand operand — syntactically invalid.
+        var lenientQuery = ParadeDbJsonQuery.Parse("neural AND",
+            lenient: true, conjunctionMode: false);
+        var strictQuery = ParadeDbJsonQuery.Parse("neural AND",
+            lenient: false, conjunctionMode: false);
+
+        // Lenient: parser ignores the trailing operator and matches "neural" → Article 1.
+        var lenientHits = await ctx.Articles
+            .JsonSearch(a => a.Id, lenientQuery)
+            .Select(a => a.Title)
+            .ToListAsync();
+        Assert.Contains(lenientHits, t => t == "Introduction to neural networks");
+
+        // Strict: pg_search rejects the malformed query at execution time.
+        await Assert.ThrowsAsync<PostgresException>(async () =>
+            await ctx.Articles
+                .JsonSearch(a => a.Id, strictQuery)
+                .Select(a => a.Title)
+                .ToListAsync());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test that contrasts `ParadeDbJsonQuery.Parse(..., lenient: true, ...)` vs `lenient: false` end-to-end. The already-merged `JsonParseOptionsTests` pins `lenient: true` in both halves to isolate `conjunction_mode`, so the `lenient` JSON-key branch was never validated.
- Uses a malformed query (`"neural AND"`) — pg_search rejects it strictly and tolerates it leniently. A regression that drops the `"lenient"` key emission (same bug pattern as `FuzzyTerm` GH-47) would let the strict case parse silently.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonParseLenientTests.cs` — new test asserting the lenient query returns Article 1 and the strict query throws `Npgsql.PostgresException`.