### PR TITLE
test(integration): add JSON Match 2-arg field-restriction test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchFieldTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchFieldTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonMatchFieldTests(ParadeDbFixture fixture) {
+    // Verifies the 2-arg ParadeDbJsonQuery.Match(value, field) overload restricts
+    // the match to the named field. The C# parameter order (value, field) is the
+    // opposite of the resulting JSON key order ({"field":..., "value":...}); a
+    // refactor that "aligns" param order with the JSON would silently invert
+    // every caller. The 4-arg overload is the only currently-tested Match shape.
+    [Fact]
+    public async Task Match_WithFieldAndValue_RestrictsToNamedField() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // "models" appears in Article 1 and Article 2 content (stems to "model"),
+        // and in NO article title. A param swap would search field "models"
+        // (non-existent) and error, or search title and return zero from content.
+        var titleQuery = ParadeDbJsonQuery.Match("models", "title");
+        var contentQuery = ParadeDbJsonQuery.Match("models", "content");
+
+        var titleHits = await ctx.Articles
+            .JsonSearch(a => a.Id, titleQuery)
+            .Select(a => a.Title)
+            .ToListAsync();
+        var contentHits = await ctx.Articles
+            .JsonSearch(a => a.Id, contentQuery)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        // Title-restricted: zero hits — "models" doesn't appear in any title.
+        Assert.Empty(titleHits);
+        // Content-restricted: Articles 1 and 2 both have "models" in content.
+        Assert.Contains(contentHits, t => t == "Introduction to neural networks");
+        Assert.Contains(contentHits, t => t == "Transformer architectures");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test for the previously-untested 2-arg `ParadeDbJsonQuery.Match(value, field)` overload.
- The C# parameter order `(value, field)` is the opposite of the resulting JSON key order `("field", "value")`; a refactor that "aligns" the param order with the JSON would silently swap every caller's field and value. Nothing currently catches this.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchFieldTests.cs` — new test using `"models"` (stems from Article 1 + Article 2 content, absent from all titles): `Match("models", "title")` returns empty; `Match("models", "content")` returns both articles.