### PR TITLE
test(integration): add skipped repro for GH-56 — Match 1-arg invalid JSON

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchDefaultFieldTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchDefaultFieldTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonMatchDefaultFieldTests(ParadeDbFixture fixture) {
+    // Verifies the 1-arg ParadeDbJsonQuery.Match(value) overload — emits
+    // {"match":{"value":"..."}} with no "field" key. The 2-arg and 4-arg
+    // overloads are tested elsewhere; the 1-arg path was never exercised
+    // end-to-end. Probes pg_search's documented behavior of searching across
+    // all indexed fields when no field is specified.
+    [Fact(Skip = "GH-56 — 1-arg Match overload produces JSON pg_search rejects")]
+    public async Task Match_ValueOnlyWithoutField_SearchesAllIndexedFields() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // "neural" appears in Article 1's title AND content — either field
+        // matching is enough to return the hit. Article 4 (cooking) has neither.
+        var query = ParadeDbJsonQuery.Match("neural");
+
+        var hits = await ctx.Articles
+            .JsonSearch(a => a.Id, query)
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.Contains(hits, t => t == "Introduction to neural networks");
+        Assert.DoesNotContain(hits, t => t == "Cooking pasta perfectly");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for `ParadeDbJsonQuery.Match`'s 1-arg overload that uncovered a real bug — skipped — see GH-56.
- The overload emits `{"match":{"value":"..."}}` with no `"field"` key, but pg_search rejects that shape with `"data did not match any variant of untagged enum SearchQueryInput"`. The overload exists in the public API but no caller can execute it.
- Test ships `[Fact(Skip = ...)]` so the artifact lives in the repo and can be un-skipped as part of the fix.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonMatchDefaultFieldTests.cs` — new skipped test (`[Fact(Skip = "GH-56 — ...")]`) asserting `Match("neural")` (no field) should return Article 1 ("Introduction to neural networks").