### PR TITLE
test(integration): add MatchesTermFuzzy 5-arg prefix-flag positional-arg test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesTermFuzzyPrefixTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesTermFuzzyPrefixTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class MatchesTermFuzzyPrefixTests(ParadeDbFixture fixture) {
+    // Verifies the 5-arg MatchesTermFuzzy overload's "prefix" flag — routes
+    // through BuildFuzzyTermFunc which emits pdb.fuzzy_term(value, distance,
+    // transposition_cost_one, prefix) as a POSITIONAL call. The existing
+    // MatchesTermFuzzyOptionsTests only varies transpositionCostOne (fixing
+    // prefix at false), so a regression that swaps positional args 3 and 4
+    // would slip through it but be caught here.
+    [Fact]
+    public async Task MatchesTermFuzzy_WithPrefixTrue_ExtendsMatchPastEditDistance() {
+        await using var ctx = fixture.CreateDbContext();
+
+        // "neurla" → "neural" is Levenshtein distance 2. At distance: 1 with
+        // prefix: false, no match (distance too small). With prefix: true the
+        // initial substring is exempt from edit distance, allowing the match.
+        var prefixOff = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTermFuzzy(a.Content, "neurla", 1,
+                prefix: false, transpositionCostOne: false))
+            .Select(a => a.Title)
+            .ToListAsync();
+        var prefixOn = await ctx.Articles
+            .Where(a => EF.Functions.MatchesTermFuzzy(a.Content, "neurla", 1,
+                prefix: true, transpositionCostOne: false))
+            .Select(a => a.Title)
+            .ToListAsync();
+
+        Assert.DoesNotContain(prefixOff, t => t == "Introduction to neural networks");
+        Assert.Contains(prefixOn, t => t == "Introduction to neural networks");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test for the previously-unexercised `prefix` flag on the 5-arg `MatchesTermFuzzy` overload, which routes through `BuildFuzzyTermFunc` and emits `pdb.fuzzy_term(value, distance, transposition_cost_one, prefix)` as a POSITIONAL function call (distinct from the named-arg `pdb.match` path that the `MatchesFuzzy`/`MatchesAllFuzzy` 5-arg overloads use).
- The existing `MatchesTermFuzzyOptionsTests` only varies `transpositionCostOne` with `prefix` fixed at false — a regression that swaps positional args 3 and 4 (both `bool`) would slip through it but be caught here.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/MatchesTermFuzzyPrefixTests.cs` — new test using `"neurla"` (Levenshtein 2 from `"neural"`) at `distance: 1`: `prefix: false` does not match, `prefix: true` matches Article 1.