### PR TITLE
fix(json-query): always emit boolean option keys in JSON query builder

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs
@@ -10,7 +10,7 @@ public class JsonFuzzyTermOptionsTests(ParadeDbFixture fixture) {
     // the CLR MatchesTermFuzzy 5-arg path (pdb.fuzzy_term positional function).
     // A regression renaming "transposition_cost_one" (or hard-coding it) would
     // silently make distance=1 reject the adjacent-swap that the test relies on.
-    [Fact(Skip = "GH-47 — JSON FuzzyTerm transpositionCostOne=false is indistinguishable from true")]
+    [Fact]
     public async Task FuzzyTerm_WithTranspositionCostOne_MatchesAdjacentSwapAtDistance1() {
         await using var ctx = fixture.CreateDbContext();
 

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
@@ -36,9 +36,11 @@ public sealed class ParadeDbJsonQuery {
     /// Parse query with options. Produces: <c>{"parse":{"query_string":"...","lenient":true,"conjunction_mode":true}}</c>.
     /// </summary>
     public static ParadeDbJsonQuery Parse(string queryString, bool lenient, bool conjunctionMode) {
-        var inner = new JsonObject { ["query_string"] = queryString };
-        if (lenient) inner["lenient"] = true;
-        if (conjunctionMode) inner["conjunction_mode"] = true;
+        var inner = new JsonObject {
+            ["query_string"] = queryString,
+            ["lenient"] = lenient,
+            ["conjunction_mode"] = conjunctionMode
+        };
         return new(new JsonObject { ["parse"] = inner });
     }
 
@@ -79,8 +81,12 @@ public sealed class ParadeDbJsonQuery {
     /// Match query with field and options.
     /// </summary>
     public static ParadeDbJsonQuery Match(string value, string field, int distance, bool conjunctionMode) {
-        var inner = new JsonObject { ["field"] = field, ["value"] = value, ["distance"] = distance };
-        if (conjunctionMode) inner["conjunction_mode"] = true;
+        var inner = new JsonObject {
+            ["field"] = field,
+            ["value"] = value,
+            ["distance"] = distance,
+            ["conjunction_mode"] = conjunctionMode
+        };
         return new(new JsonObject { ["match"] = inner });
     }
 
@@ -96,9 +102,13 @@ public sealed class ParadeDbJsonQuery {
     /// Fuzzy term match with full options.
     /// </summary>
     public static ParadeDbJsonQuery FuzzyTerm(string field, string value, int distance, bool prefix, bool transpositionCostOne) {
-        var inner = new JsonObject { ["field"] = field, ["value"] = value, ["distance"] = distance };
-        if (prefix) inner["prefix"] = true;
-        if (transpositionCostOne) inner["transposition_cost_one"] = true;
+        var inner = new JsonObject {
+            ["field"] = field,
+            ["value"] = value,
+            ["distance"] = distance,
+            ["prefix"] = prefix,
+            ["transposition_cost_one"] = transpositionCostOne
+        };
         return new(new JsonObject { ["fuzzy_term"] = inner });
     }
 


### PR DESCRIPTION
## Summary

- Fixes [#47](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/issues/47): `ParadeDbJsonQuery.FuzzyTerm`'s `transpositionCostOne: false` was indistinguishable from `true` on the JSON `@@@` path.
- Root cause: three JSON builder factories (`FuzzyTerm` 5-arg, `Parse` 3-arg, `Match` 4-arg) only emitted their boolean option keys when `true`. With the key omitted, ParadeDB falls back to its own default (e.g. `transposition_cost_one` defaults to `true` in pg_search) — making the `false` case unreachable from the JSON builder.
- Fix: always emit the option keys with their actual boolean value, and unskip the GH-47 regression test (`JsonFuzzyTermOptionsTests`).

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs` — `FuzzyTerm` 5-arg, `Parse` 3-arg, and `Match` 4-arg now always emit `prefix`, `transposition_cost_one`, `lenient`, and `conjunction_mode` with their actual boolean value rather than only on `true`.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonFuzzyTermOptionsTests.cs` — dropped the `Skip = "GH-47 — ..."` argument now that the fix lands.