### PR TITLE
fix(json-query): emit null bound instead of omitting key in Range

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs
@@ -9,7 +9,7 @@ public class JsonRangeOpenEndedTests(ParadeDbFixture fixture) {
     // existing JsonQueryTests/JsonDateTimeRangeTests always pass both bounds,
     // so a regression that always emits "upper_bound" (or crashes on null)
     // would only be caught here.
-    [Fact(Skip = "GH-51 — passing null bound emits JSON pg_search rejects (missing field upper_bound panic)")]
+    [Fact]
     public async Task Range_WithNullUpperBound_MatchesAllValuesAtOrAboveLowerBound() {
         await using var ctx = fixture.CreateDbContext();
 

--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs
@@ -163,8 +163,8 @@ public class ParadeDbJsonQueryTests {
         var json = ParadeDbJsonQuery.Range("Price", 10, null).ToJson();
         var doc = Parse(json);
         var range = doc.GetProperty("range");
-        Assert.True(range.TryGetProperty("lower_bound", out _));
-        Assert.False(range.TryGetProperty("upper_bound", out _));
+        Assert.Equal(10, range.GetProperty("lower_bound").GetProperty("included").GetInt32());
+        Assert.Equal(JsonValueKind.Null, range.GetProperty("upper_bound").ValueKind);
     }
 
     [Fact]
@@ -179,8 +179,8 @@ public class ParadeDbJsonQueryTests {
     public void Range_with_upper_bound_only_creates_correct_json() {
         var json = ParadeDbJsonQuery.Range("Price", null, 100).ToJson();
         var range = Parse(json).GetProperty("range");
-        Assert.False(range.TryGetProperty("lower_bound", out _));
-        Assert.True(range.TryGetProperty("upper_bound", out _));
+        Assert.Equal(JsonValueKind.Null, range.GetProperty("lower_bound").ValueKind);
+        Assert.Equal(100, range.GetProperty("upper_bound").GetProperty("excluded").GetInt32());
     }
 
     [Fact]

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs
@@ -149,20 +149,21 @@ public sealed class ParadeDbJsonQuery {
 
     /// <summary>
     /// Range query. Produces bounds as <c>{"included":N}</c> or <c>{"excluded":N}</c>.
-    /// Pass <c>null</c> for either bound to omit it.
+    /// Pass <c>null</c> for either bound to make that side unbounded (emitted as JSON <c>null</c>,
+    /// which pg_search requires — omitting the key throws a deserialization panic).
     /// Set <paramref name="isDatetime"/> to true for DateTime range queries (adds <c>"is_datetime":true</c>).
     /// </summary>
     public static ParadeDbJsonQuery Range(string field, object lowerBound, object upperBound,
         bool lowerInclusive = true, bool upperInclusive = false, bool isDatetime = false) {
-        var inner = new JsonObject { ["field"] = field };
-        if (lowerBound != null) {
-            var key = lowerInclusive ? "included" : "excluded";
-            inner["lower_bound"] = new JsonObject { [key] = CreateJsonValue(lowerBound) };
-        }
-        if (upperBound != null) {
-            var key = upperInclusive ? "included" : "excluded";
-            inner["upper_bound"] = new JsonObject { [key] = CreateJsonValue(upperBound) };
-        }
+        var inner = new JsonObject {
+            ["field"] = field,
+            ["lower_bound"] = lowerBound != null
+                ? new JsonObject { [lowerInclusive ? "included" : "excluded"] = CreateJsonValue(lowerBound) }
+                : null,
+            ["upper_bound"] = upperBound != null
+                ? new JsonObject { [upperInclusive ? "included" : "excluded"] = CreateJsonValue(upperBound) }
+                : null
+        };
         if (isDatetime) inner["is_datetime"] = true;
         return new(new JsonObject { ["range"] = inner });
     }


### PR DESCRIPTION
## Summary

- Fixes [#51](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/issues/51): `ParadeDbJsonQuery.Range` with a `null` bound emitted JSON pg_search rejects at runtime with a Rust panic — `called Result::unwrap() on an Err value: Error("missing field upper_bound", ...)`.
- Root cause confirmed against pg_search source: the range query JSON requires **both** `lower_bound` and `upper_bound` keys to be present. An unbounded side is represented by `null` as the value, not by omitting the key. Verified from pg_search's own [`tests/tests/range_json.rs`](https://github.com/paradedb/paradedb/blob/main/tests/tests/range_json.rs) — the canonical open-ended shape is `{"range":{"field":"x","lower_bound":{"included":N},"upper_bound":null}}`.
- Fix: always emit both bound keys, using JSON `null` when the C# argument is null. Update the doc-comment to reflect the corrected semantics.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs` — `Range` now emits both `lower_bound` and `upper_bound` unconditionally; the value is `null` when the corresponding C# bound is null. Doc-comment clarifies that `null` becomes JSON `null` (omitting the key would panic).
- `Equibles.ParadeDB.EntityFrameworkCore.Tests/ParadeDbJsonQueryTests.cs` — `Range_with_lower_bound_only_creates_correct_json` and `Range_with_upper_bound_only_creates_correct_json` now assert the new shape (key present, value `null`) instead of the old broken behavior (key absent).
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonRangeOpenEndedTests.cs` — dropped the `Skip = "GH-51 — ..."` argument now that the fix lands.