### PR TITLE
fix(tests): match nullable signature on StubSqlExpression.Equals override

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
@@ -15,7 +15,7 @@ public class ExpressionTests {
         protected override System.Linq.Expressions.Expression VisitChildren(
             System.Linq.Expressions.ExpressionVisitor visitor) => this;
         protected override void Print(ExpressionPrinter expressionPrinter) => expressionPrinter.Append(_token);
-        public override bool Equals(object obj) => obj is StubSqlExpression other && other._token == _token;
+        public override bool Equals(object? obj) => obj is StubSqlExpression other && other._token == _token;
         public override int GetHashCode() => _token.GetHashCode();
 #if NET9_0_OR_GREATER
         public override System.Linq.Expressions.Expression Quote() => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

- Prereq for enabling `-warnaserror` in CI. The Tests project has `<Nullable>enable</Nullable>`, but `StubSqlExpression.Equals(object obj)` overrode the base `Equals(object? obj)` with a non-nullable parameter, triggering `CS8765` across net8/net9/net10.
- One-character change: `object obj` → `object? obj`.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs` — annotate the `Equals` override parameter as nullable to match the base signature.