### PR TITLE
chore: ignore CSharpier format-pass commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Revisions listed here are skipped by `git blame` and the GitHub blame view.
+# Use for purely mechanical changes (formatting, mass renames) so authorship
+# survives.
+#
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# One-time CSharpier format pass (PR #64).
+fa8e78714cf82f3c61fe3c7b025ba2ee6bc9674c


### PR DESCRIPTION
## Summary

- Adds `.git-blame-ignore-revs` referencing the squashed commit from #64 (`fa8e787`) so `git blame` and GitHub's blame view skip the mass reformat and continue to attribute lines to their original authors.
- Documents the local opt-in: `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## Code changes

- `.git-blame-ignore-revs` — new file with one ignored revision (the CSharpier format pass).