### PR TITLE
ci: split into lint + build matrix with warnings-as-errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,64 @@ on:
     branches: [master]
   workflow_dispatch:
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
+jobs:
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Check formatting
+        run: dotnet csharpier check .
 
       - name: Restore
         run: dotnet restore
 
-      - name: Build
-        run: dotnet build -c Release --no-restore
+      - name: Build (warnings as errors)
+        run: dotnet build -c Release --no-restore -warnaserror
 
-      - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: [net8.0, net9.0, net10.0]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (${{ matrix.framework }})
+        run: dotnet build -c Release --no-restore --framework ${{ matrix.framework }}
+
+      - name: Test (${{ matrix.framework }})
+        run: dotnet test -c Release --no-build --framework ${{ matrix.framework }} --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
+        if: matrix.framework == 'net10.0'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Refactors the single CI job into two: a `lint` job (CSharpier format check + `-warnaserror` build) and a `build` matrix across net8/net9/net10.
- Adds a `concurrency` group keyed on PR/branch so superseded runs are cancelled (saves Actions minutes and avoids stale status checks).
- Codecov upload is gated to the net10 matrix entry to avoid duplicate reports.

## Code changes

- `.github/workflows/ci.yml` — rewritten with `lint` and `build` jobs, matrix on `framework: [net8.0, net9.0, net10.0]`, `concurrency` cancel-in-progress, and Codecov upload only on net10.

## Notes

- Integration tests target net10.0 only, so net8/net9 matrix entries run unit tests only — which is exactly what's needed to catch TFM-specific breakage in the library + unit suite.
- The `lint` job uses `dotnet csharpier check` against the `.config/dotnet-tools.json` manifest added in #64.
- Verified locally: `dotnet csharpier check .` passes, `dotnet build -warnaserror` produces 0 warnings/errors, full test suite passes on net10.