### PR TITLE
chore: add pre-commit hook bundle (prek-compatible)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./bin,./obj,./worktrees,./.config,*.lock,*.lockfile,./TestResults
+ignore-words = .codespellignore

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,8 @@
+default: true
+
+# MD013 line-length — prose lines aren't worth wrapping at 80.
+MD013: false
+# MD024 duplicate headings — common in changelogs/READMEs with repeated section names.
+MD024: false
+# MD033 inline HTML — README uses <details>, <kbd>, etc.
+MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "master"]
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-json
+      - id: detect-private-key
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+      - id: markdownlint
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: ["--config", ".codespellrc", "--check-filenames"]
+
+  - repo: local
+    hooks:
+      - id: csharpier
+        name: csharpier format
+        entry: dotnet csharpier check
+        language: system
+        files: \.(cs|csproj|props|slnx)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -500,6 +500,18 @@ All of this is translated into standard EF Core migrations — no manual SQL req
 
 LINQ methods on `EF.Functions` are translated to SQL via `IMethodCallTranslatorPlugin`. The mapping for each method is shown alongside its example in the [Querying](#querying) section above.
 
+## Contributing
+
+The repo uses [CSharpier](https://csharpier.com) for formatting and a [`prek`](https://github.com/j178/prek) (or `pre-commit`-compatible) hook bundle for the usual hygiene checks (`end-of-file-fixer`, `trailing-whitespace`, `markdownlint`, `codespell`, etc.).
+
+```bash
+dotnet tool restore                 # installs CSharpier locally
+prek install -f                     # installs the pre-commit hooks
+prek run --all-files                # one-off sweep over the whole repo
+```
+
+CI runs the same checks (CSharpier check + `-warnaserror` build) in the `lint` job, so even contributors who skip the local hooks get caught at PR time.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with the standard hygiene bundle (line endings, trailing whitespace, EOF newlines, YAML/JSON/private-key checks), markdownlint, codespell, and a local CSharpier hook.
- Configures markdownlint with relaxed rules (`MD013` off — no prose wrapping; `MD024` off — duplicate headings allowed in changelogs; `MD033` off — README uses inline HTML).
- Adds `.codespellrc` with sensible skip patterns.
- Documents install/run in the README's new Contributing section.

## Code changes

- `.pre-commit-config.yaml` — new hook configuration.
- `.markdownlint.yaml` — relaxed rules so existing README passes.
- `.codespellrc` + `.codespellignore` — typo checker config and empty allowlist.
- `README.md` — new "Contributing" section with `dotnet tool restore` + `prek install -f` + `prek run --all-files`.

## Notes

- Hooks are developer convenience (skippable via `--no-verify`). The hard gate is the CI lint job (PR #66) which runs the equivalent CSharpier check and `-warnaserror` build.
- Existing files may need a one-time `prek run --all-files` sweep (trailing whitespace, EOL newlines). Worth doing as a separate cleanup PR if any failures show up.