### PR TITLE
ci: lint PR titles against Conventional Commits

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a workflow using [`amannn/action-semantic-pull-request@v5`](https://github.com/amannn/action-semantic-pull-request) to validate every PR title against the Conventional Commits spec.
- The repo already follows the convention (e.g. `fix(json-query): ...`, `test(integration): ...`, `ci: ...`) — this just enforces it for external contributors via a required check.
- Uses default config (built-in list of accepted types). No additional secrets needed; the workflow has read-only `pull-requests` permission.

## Code changes

- `.github/workflows/lint-pr-title.yml` — new workflow firing on `opened`, `edited`, `synchronize` PR events.