### PR TITLE
ci: add Dependabot with grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+      entityframework:
+        patterns:
+          - "*EntityFrameworkCore*"
+          - "Npgsql*"
+      testing:
+        patterns:
+          - "xunit*"
+          - "Testcontainers*"
+          - "coverlet*"
+          - "*Testing*"
+      tooling:
+        patterns:
+          - "CSharpier*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for NuGet and GitHub Actions dependencies.
- Groups related NuGet packages so a Microsoft.* / Npgsql / xunit / Testcontainers bump arrives as a single PR rather than a flood.
- Caps each ecosystem at 3 open PRs to keep the review queue manageable.
- GitHub Actions updates are bundled into one PR per week.

## Code changes

- `.github/dependabot.yml` — new config with four NuGet groups (microsoft, entityframework, testing, tooling) plus a single all-actions group for GitHub Actions.