### PR TITLE
ci: multi-target IntegrationTests across net8/net9/net10

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
@@ -1,19 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!-- C# 14 allows named-argument syntax inside expression trees; tests rely on it.
+         Force latest LangVersion so the net8/net9 TFMs use the same compiler features. -->
+    <LangVersion>latest</LangVersion>
     <NoWarn>EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Fixes the matrix net8/net9 build failures introduced by #66 by addressing the actual root cause: IntegrationTests was net10-only, so the matrix's `--framework net8.0`/`net9.0` build commands tripped on `NETSDK1005`.
- More important than the CI green: the library has TFM-conditional package references (`Npgsql.EntityFrameworkCore.PostgreSQL` 8.0.11 / 9.0.4 / 10.0.1) and TFM-conditional code paths. Before this PR, none of those net8/net9 paths were exercised end-to-end. Now they are.
- Picks up a C# 14 compiler dependency: several tests use named arguments inside LINQ expression trees, which C# 12/13 reject with `CS0853`. Pinning `<LangVersion>latest</LangVersion>` makes the C# 14 compiler available on every TFM. The emitted IL is compatible with net8/net9 runtimes (verified: 69 tests pass on each).

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj`:
  - `<TargetFramework>net10.0</TargetFramework>` → `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>`.
  - Added `<LangVersion>latest</LangVersion>` with a one-line comment explaining why.
  - Replaced the unconditional `Npgsql.EntityFrameworkCore.PostgreSQL 10.0.1` reference with three TFM-conditional `<ItemGroup>` blocks (8.0.11 / 9.0.4 / 10.0.1), matching the pattern in the main library csproj.