### PR TITLE
fix(tests): bump Testcontainers and use new image-arg constructor

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.7.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
@@ -5,8 +5,7 @@ namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
 
 public sealed class ParadeDbFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("paradedb/paradedb:latest")
         .WithDatabase("paradedb_test")
         .WithUsername("postgres")
         .WithPassword("postgres")


### PR DESCRIPTION
## Summary

- Dependabot's testing-group PR (#72) bumped `Testcontainers.PostgreSql` 4.7.0 → 4.11.0, which deprecates the parameterless `PostgreSqlBuilder()` constructor ([testcontainers/testcontainers-dotnet#1470](https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721)). Under `-warnaserror` from PR #66, the obsolete warning becomes a hard error.
- This PR ships the same bump together with the migrated call site so the CI lint job goes green. Dependabot's #72 will rebase to drop the now-redundant Testcontainers bump (it'll keep just the coverlet and xunit.runner.visualstudio bumps).

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests.csproj` — `Testcontainers.PostgreSql` 4.7.0 → 4.11.0.
- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs:8` — `new PostgreSqlBuilder().WithImage(\"paradedb/paradedb:latest\")` → `new PostgreSqlBuilder(\"paradedb/paradedb:latest\")`. The `.WithDatabase`/`.WithUsername`/`.WithPassword`/`.Build()` chain is unchanged.

## Verified

Build clean on all three TFMs with `-warnaserror`; 69 integration tests pass on net10 locally.