### PR TITLE
style: apply CSharpier formatting to ParadeDbFixture

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs
@@ -5,7 +5,9 @@ namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
 
 public sealed class ParadeDbFixture : IAsyncLifetime
 {
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("paradedb/paradedb:latest")
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder(
+        "paradedb/paradedb:latest"
+    )
         .WithDatabase("paradedb_test")
         .WithUsername("postgres")
         .WithPassword("postgres")


### PR DESCRIPTION
## Summary

- The change in #74 (`new PostgreSqlBuilder(\"paradedb/paradedb:latest\")...`) produced a line that exceeds CSharpier's print width, failing the lint job on master.
- Re-runs CSharpier on the affected file to wrap the constructor call.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/ParadeDbFixture.cs` — constructor call wrapped per CSharpier's formatting rule. No behavior change.