### PR TITLE
chore: allowlist fuzzy-search misspellings and fix README list spacing

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,4 @@
+nueral
+netwroks
+lerning
+transfomers

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ dotnet ef database update
 ```
 
 EF Core will generate the migration automatically, creating:
+
 - The `pg_search` PostgreSQL extension
 - A BM25 index on the specified columns with the `key_field` storage parameter and per-column `text_fields` / `numeric_fields` / `boolean_fields` / `datetime_fields` / `json_fields` JSON derived from any `[Bm25Text]` / `[Bm25Numeric]` / etc. attributes
 


### PR DESCRIPTION
## Summary

First `prek run --all-files` after installing the hooks surfaced two cleanup items:

1. **codespell allowlist** — the test suite and README examples deliberately use misspelled fuzzy-search inputs (`\"nueral\"`, `\"netwroks\"`, `\"lerning\"`, `\"transfomers\"`) to demonstrate / verify that `MatchesFuzzy` tolerates typos. codespell wanted to "fix" them, which would silently destroy the test premise. Adding to `.codespellignore`.
2. **markdownlint MD032** — `README.md:105` has a bullet list directly following a paragraph; rule wants a blank line between them. One-line fix.

No real typos were found.

## Code changes

- `.codespellignore` — added `nueral`, `netwroks`, `lerning`, `transfomers` (all intentional fuzzy-search test fixtures and doc examples).
- `README.md` — inserted a blank line before the bullet list in the Setup section so MD032 is satisfied.

## Verified

`prek run --all-files` now passes every hook.