### PR TITLE
docs: add SECURITY, CONTRIBUTING, and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<dev2@comudel.com>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+Thanks for considering a contribution. This is a small library; PRs that fix bugs, add tests, or extend the search API are welcome.
+
+## Getting set up
+
+```bash
+git clone https://github.com/daniel3303/ParadeDbEntityFrameworkCore.git
+cd ParadeDbEntityFrameworkCore
+dotnet tool restore        # installs CSharpier locally
+prek install -f            # installs git pre-commit hooks (https://github.com/j178/prek)
+prek run --all-files       # one-off sweep
+```
+
+You'll also need Docker running locally — the integration test suite spins up a `paradedb/paradedb:latest` container via Testcontainers.
+
+## Branching and commit style
+
+- Branch from `master` using a prefix: `feature/`, `fix/`, `chore/`, `docs/`.
+- Commits and PR titles follow [Conventional Commits](https://www.conventionalcommits.org). The PR-title workflow blocks merges that don't comply.
+- Examples: `fix(json-query): ...`, `feat(translator): ...`, `test(integration): ...`, `docs(readme): ...`.
+
+## Build, format, test
+
+```bash
+dotnet build -warnaserror                   # must produce 0 warnings
+dotnet csharpier check .                    # must produce no diff (the lint job runs this in CI)
+dotnet test                                 # unit + integration, all TFMs (net8/net9/net10)
+```
+
+The integration suite uses Testcontainers — Docker must be running.
+
+## Adding a feature
+
+1. Open an issue first if the scope isn't obvious — saves wasted effort.
+2. Write the test before the production code (or alongside). For LINQ translator changes, both a unit test (asserts the generated SQL string) and an integration test (asserts the result set against real pg_search) are expected.
+3. Keep PRs focused — one logical change per PR. Split unrelated changes into separate PRs.
+4. Update `CHANGELOG.md` under the `## [Unreleased]` section.
+
+## Reporting bugs
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug.yml). Include:
+
+- Library version + .NET version + Npgsql.EFCore version + ParadeDB version.
+- The LINQ query and the generated SQL (turn on `LogTo(Console.WriteLine)` on your `DbContext`).
+- Expected vs. observed result.
+
+## Security
+
+Don't open public issues for vulnerabilities — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+The latest published NuGet release receives security updates. Older versions are not actively patched — upgrade to the latest minor release first when reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest minor | ✅ |
+| Older | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new) (preferred), or email <dev2@comudel.com>.
+
+When reporting, include:
+
+- A clear description of the issue and the impact you observed.
+- A minimal reproduction (LINQ snippet, schema, query, or repro repo).
+- Affected version(s) of `Equibles.ParadeDB.EntityFrameworkCore`, `Npgsql.EntityFrameworkCore.PostgreSQL`, .NET runtime, and ParadeDB / pg_search.
+- Any suggested remediation, if applicable.
+
+### Response timeline
+
+- **Acknowledgement**: within 3 business days.
+- **Initial assessment**: within 7 business days.
+- **Fix or mitigation**: depends on severity; coordinated disclosure expected before any public details.
+
+Reporters are credited in the release notes unless they prefer to remain anonymous.


### PR DESCRIPTION
## Summary

Adds the three standard community-health files GitHub surfaces on the repo's Insights → Community Standards page. Together with the existing README and LICENSE, this gets the repo to ✅ on every metric GitHub tracks for community-standards.

## Code changes

- `SECURITY.md` — vulnerability reporting policy. Uses GitHub's private vulnerability reporting (preferred) plus email fallback. Documents response SLA (3 business days ack, 7 days assessment).
- `CONTRIBUTING.md` — setup steps (`dotnet tool restore` + `prek install`), branching prefixes, Conventional Commits, build/format/test commands, bug-report expectations.
- `CODE_OF_CONDUCT.md` — verbatim [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), enforcement contact filled in with `<dev2@comudel.com>`. The canonical text is what GitHub's detector recognizes.

All three pass `prek run` cleanly (markdownlint, codespell, EOF, whitespace).