### PR TITLE
fix(docs): correct contact email in SECURITY and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<dev2@comudel.com>.
+<hello@danielapoliveira.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest published NuGet release receives security updates. Older versions are
 
 **Please do not open a public GitHub issue for security problems.**
 
-Use GitHub's [private vulnerability reporting](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new) (preferred), or email <dev2@comudel.com>.
+Use GitHub's [private vulnerability reporting](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new) (preferred), or email <hello@danielapoliveira.com>.
 
 When reporting, include:
 


### PR DESCRIPTION
## Summary

PR #80 landed with the wrong contact email (`dev2@comudel.com`). Replace with `hello@danielapoliveira.com` in both files so vulnerability reports and code-of-conduct enforcement reach the right inbox.

## Code changes

- `SECURITY.md` — updated the `mailto:` link.
- `CODE_OF_CONDUCT.md` — updated the enforcement contact in the Enforcement section.