### PR TITLE
chore(github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a bug in the library
+title: "Bug: <one-line summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the
+        sections below so the issue can be reproduced quickly.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong, in one or two sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: |
+        The smallest LINQ snippet (and entity / DbContext setup) that triggers
+        the issue. Inline code blocks or a link to a minimal repro repo.
+      render: csharp
+    validations:
+      required: true
+
+  - type: textarea
+    id: generated-sql
+    attributes:
+      label: Generated SQL (if applicable)
+      description: |
+        Enable EF Core query logging (`LogTo(Console.WriteLine)` on the
+        `DbContextOptionsBuilder`) and paste the SQL that was emitted.
+      render: sql
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Include the full exception type, message, and stack trace if any.
+    validations:
+      required: true
+
+  - type: input
+    id: library-version
+    attributes:
+      label: Library version
+      description: "`Equibles.ParadeDB.EntityFrameworkCore` NuGet version."
+      placeholder: e.g. 0.4.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dotnet
+    attributes:
+      label: .NET version
+      options:
+        - .NET 8
+        - .NET 9
+        - .NET 10
+    validations:
+      required: true
+
+  - type: input
+    id: npgsql-version
+    attributes:
+      label: Npgsql.EntityFrameworkCore.PostgreSQL version
+      placeholder: e.g. 10.0.1
+    validations:
+      required: true
+
+  - type: input
+    id: paradedb-version
+    attributes:
+      label: ParadeDB / pg_search version
+      description: The Docker image tag or pg_search extension version reported by `SELECT extversion FROM pg_extension WHERE extname = 'pg_search';`.
+      placeholder: e.g. paradedb/paradedb:latest, pg_search 0.18.4
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else relevant — workarounds tried, related issues, links to upstream ParadeDB bugs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new
+    about: Use private vulnerability reporting — do not open a public issue.
+  - name: ParadeDB / pg_search question
+    url: https://github.com/paradedb/paradedb/discussions
+    about: Questions about ParadeDB itself (not this EF Core wrapper) are best asked upstream.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new feature or API
+title: "Feature: <one-line summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case. What can't you do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: |
+        Sketch the LINQ / attribute surface or the SQL shape you'd expect.
+        Concrete examples beat abstract descriptions.
+      render: csharp
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds have you tried? Why aren't they sufficient?
+
+  - type: textarea
+    id: paradedb-link
+    attributes:
+      label: Upstream ParadeDB / pg_search docs
+      description: |
+        Link to the relevant pg_search query or SQL function this would expose.
+        Helps verify the feature is actually supported by ParadeDB.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+Title: follow Conventional Commits — `fix:`, `feat:`, `chore:`, `docs:`, `test:`, `ci:`, `refactor:`, `style:`.
+A PR-title-lint workflow blocks merges that don't comply.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Link to any issue this closes (e.g. `Closes #123`). -->
+
+## Code changes
+
+<!--
+Per-file or per-area bullet list of what the change does.
+Example:
+- `Equibles.ParadeDB.EntityFrameworkCore/ParadeDbJsonQuery.cs` — emit `null` for unbounded range sides instead of omitting the key.
+- `…/JsonRangeOpenEndedTests.cs` — unskip the regression test now that the fix lands.
+-->
+
+## Verification
+
+<!--
+How did you verify this works?
+- `dotnet build -warnaserror` — clean
+- `dotnet test` — N tests pass
+- Manual repro — describe
+-->
+
+## Checklist
+
+- [ ] PR title is a Conventional Commit
+- [ ] `dotnet csharpier check .` passes
+- [ ] `dotnet build -warnaserror` produces 0 warnings
+- [ ] `dotnet test` passes on all TFMs the change affects
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (if user-visible)


### PR DESCRIPTION
## Summary

Adds GitHub-native issue forms (`bug.yml`, `feature.yml`) and a PR template. These drive the quality of incoming reports and PRs and surface in the New Issue / Open PR UI by default.

## Code changes

- `.github/ISSUE_TEMPLATE/bug.yml` — structured bug report. Required fields: summary, minimal repro, expected, actual, library version, .NET version, Npgsql.EFCore version. Optional: generated SQL, ParadeDB version.
- `.github/ISSUE_TEMPLATE/feature.yml` — feature request: problem, proposed API, alternatives, upstream pg_search link.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; routes security reports to private vuln reporting and pg_search questions upstream to the ParadeDB discussions board.
- `.github/pull_request_template.md` — Summary / Code changes / Verification / Checklist sections matching the PR style this repo already uses.