### PR TITLE
chore(docs): drop email contact in favor of GitHub private reporting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-<hello@danielapoliveira.com>.
+reported to the community leaders responsible for enforcement via
+[GitHub's private reporting form](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest published NuGet release receives security updates. Older versions are
 
 **Please do not open a public GitHub issue for security problems.**
 
-Use GitHub's [private vulnerability reporting](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new) (preferred), or email <hello@danielapoliveira.com>.
+Use GitHub's [private vulnerability reporting](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/advisories/new). The repo's maintainer is notified immediately and the report stays private until disclosure is coordinated.
 
 When reporting, include:
 


### PR DESCRIPTION
## Summary

Removes the maintainer email from `SECURITY.md` and `CODE_OF_CONDUCT.md` to eliminate the email-scraping surface on the public repo. Both files now point to GitHub's private vulnerability reporting form, which is private, free, and notifies the maintainer in-app.

## Code changes

- `SECURITY.md` — drop the email fallback; private vulnerability reporting is now the sole channel.
- `CODE_OF_CONDUCT.md` — enforcement contact is now the same GitHub private reporting URL (slight overload of the security flow, but it gives the same private channel without standing up a separate form).

## Notes

The Contributor Covenant template only requires "INSERT CONTACT METHOD" — a URL is a valid contact method, no email required.