### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly Monday 04:17 UTC — off-peak to avoid Actions queue contention.
+    - cron: "17 4 * * 1"
+
+concurrency:
+  group: codeql-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          queries: security-and-quality
+
+      - name: Build
+        run: dotnet build -c Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"


### PR DESCRIPTION
## Summary

Adds GitHub's free static security analysis for public repos. Runs on PR + push to master + a weekly schedule (Monday 04:17 UTC, off-peak). Uses the broader `security-and-quality` query suite, not just `security`.

Findings will surface on the Security tab and a CodeQL badge becomes available for the README.

## Code changes

- `.github/workflows/codeql.yml` — single \"Analyze (csharp)\" job. Installs all three .NET SDKs (csproj multi-targets), builds Release, runs CodeQL init + analyze. Concurrency-cancellation on superseded runs.