### PR TITLE
fix(dependabot): add build(deps) commit prefix for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "build"
+      include: "scope"
     groups:
       microsoft:
         patterns:


### PR DESCRIPTION
## Summary

The NuGet ecosystem block in `.github/dependabot.yml` was missing a `commit-message` config, so Dependabot generated NuGet PRs with default titles like `Bump xunit.runner.visualstudio from X to Y` — these fail the PR-title-lint workflow because they're not Conventional Commits. Recent examples: PR #76, #72, #71.

The `github-actions` ecosystem already produces `build(deps): ...` titles by default; only NuGet needed the explicit prefix.

## Code changes

- `.github/dependabot.yml` — add `commit-message: { prefix: "build", include: "scope" }` to the NuGet ecosystem block.