### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Auto-assigns @daniel3303 as the reviewer for any pull request.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @daniel3303


### PR DESCRIPTION
## Summary

Add `.github/CODEOWNERS` so every pull request automatically requests review from @daniel3303. Cheap hygiene — surfaces the right reviewer in the PR sidebar without having to set it manually.

## Code changes

- `.github/CODEOWNERS` — new file mapping `*` to `@daniel3303`.