### PR TITLE
chore(github): add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: daniel3303


### PR DESCRIPTION
## Summary

Add `.github/FUNDING.yml` so the GitHub Sponsors button appears on the repo sidebar.

## Code changes

- `.github/FUNDING.yml` — `github: daniel3303`. The Sponsor button only renders if/when a GitHub Sponsors profile is enabled for the account; the file is otherwise inert.