### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             8.0.x
@@ -44,10 +44,10 @@ jobs:
       matrix:
         framework: [net8.0, net9.0, net10.0]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             8.0.x
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.framework == 'net10.0'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: '**/TestResults/**/coverage.cobertura.xml'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             8.0.x
@@ -35,7 +35,7 @@ jobs:
             10.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           languages: csharp
           queries: security-and-quality
@@ -44,6 +44,6 @@ jobs:
         run: dotnet build -c Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           category: "/language:csharp"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -11,6 +11,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary

Pin every action reference in workflows to a full commit SHA (with a `# vN.N.N` comment for readability) instead of a floating `@v4` / `@v5` tag. Mitigates supply-chain risk from a maintainer or attacker re-pointing a major-version tag at a malicious commit.

Dependabot's `github-actions` ecosystem already understands the SHA + version-comment convention and will keep both fields in sync.

## Code changes

- `.github/workflows/ci.yml` — pin `actions/checkout`, `actions/setup-dotnet`, `codecov/codecov-action`.
- `.github/workflows/codeql.yml` — pin `actions/checkout`, `actions/setup-dotnet`, `github/codeql-action/init`, `github/codeql-action/analyze`.
- `.github/workflows/lint-pr-title.yml` — pin `amannn/action-semantic-pull-request`.
- `.github/workflows/nuget-publish.yml` — pin `actions/checkout`, `actions/setup-dotnet`.

SHAs correspond to whatever each major-version tag resolves to today; nothing is being upgraded across majors as part of this change.