### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-05-14
+
 ### Fixed
 
 - `ParadeDbJsonQuery.FuzzyTerm`, `Parse`, and `Match` (4-arg) now emit their boolean option keys unconditionally so `transpositionCostOne: false` (and other `false` flags) actually disable the option instead of falling back to pg_search's default ([#60](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/pull/60), closes [#47](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/issues/47)).
@@ -82,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: `[Bm25Index]` attribute + EF Core convention to emit `pg_search` BM25 indexes via migrations.
 
-[Unreleased]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/daniel3303/ParadeDbEntityFrameworkCore/compare/v1.0.0...v1.1.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <Authors>Equibles, Daniel Oliveira</Authors>
     <Company>Equibles</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Promotes `CHANGELOG.md` `## [Unreleased]` → `## [2.1.0] — 2026-05-14`.
- Bumps `Directory.Build.props` `<Version>` 2.0.1 → 2.1.0.
- Once merged, tag `v2.1.0` will be created on the squash commit and pushed; `.github/workflows/nuget-publish.yml` will fire on the tag to publish the package to nuget.org.

## Code changes

- `CHANGELOG.md` — moved `## [Unreleased]` block to `## [2.1.0] — 2026-05-14`; added a fresh empty `## [Unreleased]`; updated the compare-link footer (`[Unreleased]` now points at `v2.1.0...HEAD`, new `[2.1.0]` row added).
- `Directory.Build.props` — `<Version>` 2.0.1 → 2.1.0.

## Why 2.1.0 (not 2.0.2 or 3.0.0)

Strict Conventional Commits → patch (no `feat:`, no `!:` markers). But the volume of work since v2.0.1 (46 PRs: 3 real bug fixes, full repo-hardening pass, CSharpier reformat, Testcontainers bump, community-health docs) makes a minor bump more honest. The "Breaking" line in the CHANGELOG (removal of the unreachable 1-arg `Match` overload in #61) is technically API removal but no working caller could exist, so a major bump would be over-honest.