### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{yml,yaml,json,md}]
+[*.{yml,yaml,json,md,xml,csproj,props,targets,slnx}]
 indent_size = 2
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig: https://editorconfig.org
+# CSharpier remains the source of truth for C# formatting; this file
+# only sets baseline conventions IDEs can apply when CSharpier hasn't run
+# (and covers non-C# files).
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,md}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Adds a minimal `.editorconfig` so IDEs apply consistent indentation, charset, and line-ending settings without per-IDE configuration. CSharpier remains the authoritative formatter for C# — this file mainly serves non-C# files (YAML, JSON, Markdown, Makefile) and provides IDE hints when CSharpier hasn't run yet.

## Code changes

- `.editorconfig` (new) — UTF-8 + LF + final newline + trailing-whitespace trim across all files; 4-space indent default, 2-space for YAML/JSON/Markdown, tab for Makefile; trailing-whitespace preserved in `.md` to keep intentional `\` line breaks.