### PR TITLE
fix(codeql): resolve open code-scanning alerts

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.Tests/ExpressionTests.cs
@@ -97,8 +97,9 @@ public class ExpressionTests
             typeof(string),
             inner.TypeMapping
         );
+        object unrelated = "not an expression";
 
-        Assert.False(a.Equals("not an expression"));
+        Assert.False(a.Equals(unrelated));
     }
 
     [Fact]
@@ -407,8 +408,9 @@ public class ExpressionTests
             typeof(string),
             arg.TypeMapping
         );
+        object unrelated = "not an expression";
 
-        Assert.False(a.Equals("not an expression"));
+        Assert.False(a.Equals(unrelated));
     }
 
     [Fact]

--- a/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModelFinalizingConvention.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore/ParadeDbModelFinalizingConvention.cs
@@ -109,11 +109,8 @@ public sealed class ParadeDbModelFinalizingConvention : IModelFinalizingConventi
         var datetimeFields = new JsonObject();
         var jsonFields = new JsonObject();
 
-        foreach (var propertyName in attribute.Columns)
+        foreach (var propertyName in attribute.Columns.Where(c => c != attribute.KeyField))
         {
-            if (propertyName == attribute.KeyField)
-                continue;
-
             var property = entityType.FindProperty(propertyName);
             var propertyInfo = property?.PropertyInfo;
             if (propertyInfo == null)


### PR DESCRIPTION
## Summary

Resolves the three open CodeQL alerts on `master` ([security/code-scanning](https://github.com/daniel3303/ParadeDbEntityFrameworkCore/security/code-scanning)).

## Code changes

- **`ExpressionTests.cs`** — two tests intentionally call `Equals` with a `string` argument to verify the expression's `Equals` override returns `false` for unrelated types. CodeQL (`cs/equals-on-unrelated-types`) flagged the strongly-typed `string` argument. Cast to `object` so the call site matches the actual `Equals(object)` signature; behavior is unchanged.
- **`ParadeDbModelFinalizingConvention.cs`** — `BuildFieldTypeAnnotations` skipped the key column via `if (propertyName == attribute.KeyField) continue;` at the top of the `foreach`. Moved that filter into a `.Where(...)` clause on the enumerable, which is what `cs/linq/missed-where` recommended.

## Test plan

- [x] `dotnet build -c Release` (net8/net9/net10) — clean, 0 warnings
- [x] `dotnet test --filter ExpressionTests` — 23/23 (net10), 21/21 (net8), 23/23 (net9) passing
- [x] CI green on PR
- [x] CodeQL re-scan clears alerts 1, 2, 3