### PR TITLE
test(integration): add GroupBy + Count composition test over search filter

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SearchWithGroupByCountTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SearchWithGroupByCountTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class SearchWithGroupByCountTests(ParadeDbFixture fixture)
+{
+    // Verifies that ParadeDbQuerySqlGenerator emits a valid Postgres query when a @@@ predicate
+    // is composed with GROUP BY + COUNT — the SQL shape behind any "hits per facet" UI. No
+    // existing integration test exercises GROUP BY alongside ParadeDB operators, so a regression
+    // in aggregate composition (e.g., the search predicate getting pushed past the GROUP BY)
+    // would slip past the single-row Where/Select tests.
+    [Fact]
+    public async Task Search_GroupedByCategory_ReturnsHitCountPerCategory()
+    {
+        await using var ctx = fixture.CreateDbContext();
+
+        var counts = await ctx
+            .Articles.Where(a => EF.Functions.Matches(a.Content, "models OR pasta"))
+            .GroupBy(a => a.Category)
+            .Select(g => new { Category = g.Key, Count = g.Count() })
+            .OrderBy(x => x.Category)
+            .ToListAsync();
+
+        Assert.Contains(counts, c => c.Category == "machine-learning" && c.Count == 2);
+        Assert.Contains(counts, c => c.Category == "cooking" && c.Count == 1);
+        Assert.DoesNotContain(counts, c => c.Category == "physics");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first integration test that runs `GroupBy(...).Select(g => new { g.Key, Count = g.Count() })` over a `EF.Functions.Matches` filter. The SQL shape (search predicate in WHERE + GROUP BY + aggregate) is the one behind any "hits per facet" UI.
- A regression in `ParadeDbQuerySqlGenerator` that mishandles aggregate composition (e.g., search predicate pushed past the GROUP BY, or score function leaking into the aggregate scope) would slip past the existing single-row `Where`/`Select` tests.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/SearchWithGroupByCountTests.cs` — new `[Fact]` filtering articles by `Matches(content, "models OR pasta")`, grouping by `Category`, projecting `(Category, Count())`, and asserting `machine-learning=2`, `cooking=1`, and `physics` absent.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~SearchWithGroupByCountTests" --framework net10.0` passes locally against a `paradedb/paradedb:latest` Testcontainer.