### PR TITLE
test(integration): add JsonSearch + Snippet projection composition test

### DIFF
--- a/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonSearchWithSnippetTests.cs
+++ b/Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonSearchWithSnippetTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests;
+
+[Collection(nameof(ParadeDbCollection))]
+public class JsonSearchWithSnippetTests(ParadeDbFixture fixture)
+{
+    // Verifies pdb.snippet() highlights the matched terms when the predicate came from the
+    // JSON-DSL @@@ jsonb path rather than the direct |||/&&& operators. All existing snippet
+    // tests use EF.Functions.Matches; a regression in how the JSON @@@ predicate registers
+    // the matched row with the snippet function would slip past those.
+    [Fact]
+    public async Task JsonSearch_WithSnippetProjection_HighlightsMatchedTerms()
+    {
+        await using var ctx = fixture.CreateDbContext();
+
+        var query = ParadeDbJsonQuery.Boolean(b =>
+            b.Must(ParadeDbJsonQuery.Match("neural", "content"))
+        );
+
+        var snippets = await ctx
+            .Articles.JsonSearch(a => a.Id, query)
+            .Select(a => EF.Functions.Snippet(a.Content, "<mark>", "</mark>", 100))
+            .ToListAsync();
+
+        Assert.NotEmpty(snippets);
+        Assert.Contains(snippets, s => s != null && s.Contains("<mark>") && s.Contains("</mark>"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first integration test that runs `EF.Functions.Snippet(...)` projection on top of a `.JsonSearch(...)` predicate. Every existing snippet test uses `EF.Functions.Matches(...)`; the JSON-DSL `@@@ jsonb` predicate path was never exercised together with `pdb.snippet()`.
- Catches regressions in how the JSON @@@ predicate registers the matched row with the snippet function — a code path the existing single-predicate-API tests cannot reach.

## Code changes

- `Equibles.ParadeDB.EntityFrameworkCore.IntegrationTests/JsonSearchWithSnippetTests.cs` — new `[Fact]` that runs a `Match("neural", "content")` JSON query through `.JsonSearch(...)`, projects each row through `EF.Functions.Snippet(a.Content, "<mark>", "</mark>", 100)`, and asserts a `<mark>...</mark>` excerpt is returned.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~JsonSearchWithSnippetTests" --framework net10.0` passes locally against a `paradedb/paradedb:latest` Testcontainer.